### PR TITLE
[JENKINS-34650] global lib code should run outside sandbox

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>1.15</version>
+            <version>2.10-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -100,5 +100,11 @@
             <version>1.15</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-durable-task-step</artifactId>
+            <version>2.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.10-SNAPSHOT</version>
+            <version>2.11-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/global/GroovyShellDecoratorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/global/GroovyShellDecoratorImpl.java
@@ -11,9 +11,10 @@ import java.io.File;
 import java.net.MalformedURLException;
 
 /**
- * Adds the global shared library space into {@link GroovyClassLoader} classpath.
+ * Adds the global shared library space into classpath of the trusted {@link GroovyClassLoader}.
  *
  * @author Kohsuke Kawaguchi
+ * @see CpsFlowExecution#getTrustedShell()
  */
 @Extension
 public class GroovyShellDecoratorImpl extends GroovyShellDecorator {
@@ -21,12 +22,17 @@ public class GroovyShellDecoratorImpl extends GroovyShellDecorator {
     WorkflowLibRepository repo;
 
     @Override
-    public void configureShell(CpsFlowExecution context, GroovyShell shell) {
-        try {
-            shell.getClassLoader().addURL(new File(repo.workspace,"src").toURI().toURL());
-            shell.getClassLoader().addURL(new File(repo.workspace, UserDefinedGlobalVariable.PREFIX).toURI().toURL());
-        } catch (MalformedURLException e) {
-            throw new AssertionError(e);
-        }
+    public GroovyShellDecorator forTrusted() {
+        return new GroovyShellDecorator() {
+            @Override
+            public void configureShell(CpsFlowExecution context, GroovyShell shell) {
+                try {
+                    shell.getClassLoader().addURL(new File(repo.workspace,"src").toURI().toURL());
+                    shell.getClassLoader().addURL(new File(repo.workspace, UserDefinedGlobalVariable.PREFIX).toURI().toURL());
+                } catch (MalformedURLException e) {
+                    throw new AssertionError(e);
+                }
+            }
+        };
     }
 }


### PR DESCRIPTION
Acccess to this repository is already restricted to RUN_SCRIPT, there's
no point in further restricting this to sandbox.

This change depends on https://github.com/jenkinsci/workflow-cps-plugin/pull/33