### PR TITLE
[JENKINS-38517] Improvements to how libraries are checked out

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMRetriever.java
@@ -60,7 +60,7 @@ public class SCMRetriever extends LibraryRetriever {
     }
 
     @Override public void retrieve(String name, String version, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
-        SCMSourceRetriever.doRetrieve(scm, target, run, listener);
+        SCMSourceRetriever.doRetrieve(name, scm, target, run, listener);
     }
 
     @Override public FormValidation validateVersion(String name, String version) {


### PR DESCRIPTION
Noticed as part of [JENKINS-38517](https://issues.jenkins-ci.org/browse/JENKINS-38517), though the main thrust of that issue is really something else—that changing **Local module directory** should be discouraged.

@reviewbybees
