### PR TITLE
Now that subversion 2.7.1 is released, restoring some commented-out tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,8 +28,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.12</version>
-        <relativePath />
+        <version>2.17</version>
+        <relativePath/>
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-cps-global-lib</artifactId>
@@ -52,13 +52,13 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
     <properties>
@@ -154,6 +154,25 @@
             <artifactId>git</artifactId>
             <version>2.6.0</version>
             <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>subversion</artifactId>
+            <version>2.7.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>subversion</artifactId>
+            <version>2.7.1</version>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.tmatesoft.svnkit</groupId>
+            <artifactId>svnkit-cli</artifactId>
+            <version>1.8.14</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/FolderLibrariesTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/FolderLibrariesTest.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.List;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
+import jenkins.scm.impl.subversion.SubversionSCMSource;
 import static org.hamcrest.CoreMatchers.*;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
@@ -64,19 +65,17 @@ public class FolderLibrariesTest {
         Folder d = r.jenkins.createProject(Folder.class, "d");
         r.configRoundtrip(d);
         assertNull(d.getProperties().get(FolderLibraries.class));
-        /* TODO https://github.com/jenkinsci/git-plugin/pull/433
-        LibraryConfiguration foo = new LibraryConfiguration("foo", new SCMSourceRetriever(new GitSCMSource("foo", "https://nowhere.net/foo.git", "", "*", "", true)));
-        */
-        LibraryConfiguration bar = new LibraryConfiguration("bar", new SCMRetriever(new GitSCM("https://nowhere.net/bar.git")));
+        LibraryConfiguration foo = new LibraryConfiguration("foo", new SCMSourceRetriever(new SubversionSCMSource("foo", "https://phony.jenkins.io/foo/")));
+        LibraryConfiguration bar = new LibraryConfiguration("bar", new SCMRetriever(new GitSCM("https://phony.jenkins.io/bar.git")));
         bar.setDefaultVersion("master");
         bar.setImplicit(true);
         bar.setAllowVersionOverride(false);
-        d.getProperties().add(new FolderLibraries(Arrays.asList(/* TODO foo, */bar)));
+        d.getProperties().add(new FolderLibraries(Arrays.asList(foo, bar)));
         r.configRoundtrip(d);
         FolderLibraries prop = d.getProperties().get(FolderLibraries.class);
         assertNotNull(prop);
         List<LibraryConfiguration> libs = prop.getLibraries();
-        r.assertEqualDataBoundBeans(Arrays.asList(/* TODO foo, */bar), libs);
+        r.assertEqualDataBoundBeans(Arrays.asList(foo, bar), libs);
     }
 
     @Test public void registration() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
@@ -31,6 +31,7 @@ import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.SubmoduleConfig;
 import hudson.plugins.git.UserRemoteConfig;
 import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.scm.SubversionSCM;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -38,6 +39,8 @@ import java.util.List;
 import java.util.Map;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
+import jenkins.scm.impl.subversion.SubversionSCMSource;
+import jenkins.scm.impl.subversion.SubversionSampleRepoRule;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.GlobalVariable;
 import org.jenkinsci.plugins.workflow.cps.global.GrapeTest;
@@ -58,9 +61,7 @@ public class LibraryAdderTest {
     @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
     @Rule public JenkinsRule r = new JenkinsRule();
     @Rule public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
-    /* TODO subversion 2.7
     @Rule public SubversionSampleRepoRule sampleSvnRepo = new SubversionSampleRepoRule();
-    */
 
     @Test public void smokes() throws Exception {
         sampleRepo.init();
@@ -110,7 +111,6 @@ public class LibraryAdderTest {
         r.assertLogContains("using modified", r.buildAndAssertSuccess(p));
     }
 
-    /* TODO subversion 2.7
     @Test public void interpolationSvn() throws Exception {
         sampleSvnRepo.init();
         sampleSvnRepo.write("src/pkg/Lib.groovy", "package pkg; class Lib {static String CONST = 'initial'}");
@@ -161,7 +161,6 @@ public class LibraryAdderTest {
         p.setDefinition(new CpsFlowDefinition("@Library('stuff@trunk@" + tag + "') import pkg.Lib; echo(/using ${Lib.CONST}/)", true));
         r.assertLogContains("using initial", r.buildAndAssertSuccess(p));
     }
-    */
 
     @Test public void globalVariable() throws Exception {
         sampleRepo.init();

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryConfigurationTest.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.workflow.libs;
 
 import java.util.Collections;
+import org.hamcrest.Matchers;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.Rule;
@@ -37,8 +38,8 @@ public class LibraryConfigurationTest {
 
     @Issue("JENKINS-38550")
     @Test public void visibleRetrievers() throws Exception {
-        // TODO adjust to reflect https://github.com/jenkinsci/git-plugin/pull/433 & subversion 2.7
-        assertEquals(Collections.singletonList(r.jenkins.getDescriptorByType(SCMRetriever.DescriptorImpl.class)), r.jenkins.getDescriptorByType(LibraryConfiguration.DescriptorImpl.class).getRetrieverDescriptors());
+        assertThat(r.jenkins.getDescriptorByType(LibraryConfiguration.DescriptorImpl.class).getRetrieverDescriptors(),
+            Matchers.<LibraryRetrieverDescriptor>containsInAnyOrder(r.jenkins.getDescriptorByType(SCMSourceRetriever.DescriptorImpl.class), r.jenkins.getDescriptorByType(SCMRetriever.DescriptorImpl.class)));
     }
 
 }


### PR DESCRIPTION
Picks up https://github.com/jenkinsci/subversion-plugin/pull/168 to restore tests commented out before final merge of #10.

Uses library upload done as part of https://github.com/jenkinsci/subversion-plugin/pull/173.

@reviewbybees esp. @recena