### PR TITLE
[JENKINS-40408] Fixed concurrency bug introduced in #18

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
@@ -104,10 +104,10 @@ public class SCMSourceRetriever extends LibraryRetriever {
             throw new IOException(node.getDisplayName() + " may be offline");
         }
         try (WorkspaceList.Lease lease = computer.getWorkspaceList().allocate(dir)) {
-            delegate.checkout(run, dir, listener, node.createLauncher(listener));
+            delegate.checkout(run, lease.path, listener, node.createLauncher(listener));
             // Cannot add WorkspaceActionImpl to private CpsFlowExecution.flowStartNodeActions; do we care?
             // Copy sources with relevant files from the checkout:
-            dir.copyRecursiveTo("src/**/*.groovy,vars/*.groovy,vars/*.txt,resources/", null, target);
+            lease.path.copyRecursiveTo("src/**/*.groovy,vars/*.groovy,vars/*.txt,resources/", null, target);
         }
     }
 


### PR DESCRIPTION
[JENKINS-40408](https://issues.jenkins-ci.org/browse/JENKINS-40408)

Although #18 fixed a bug in library handling, it introduced another one. If there are multiple builds starting at the same time, then they causes a race-condition where the different builds uses the same directory to update the library.