### PR TITLE
JENKINS-41497 make library changesets in a job configurable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/ClasspathAdder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/ClasspathAdder.java
@@ -28,6 +28,7 @@ import groovy.lang.GroovyShell;
 import hudson.ExtensionPoint;
 import java.net.URL;
 import java.util.List;
+import java.util.HashMap;
 import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 
@@ -63,6 +64,6 @@ public abstract class ClasspathAdder implements ExtensionPoint {
      * @return a possibly empty list of additions
      * @throws Exception for whatever reason (will fail compilation)
      */
-    public abstract @Nonnull List<Addition> add(@Nonnull CpsFlowExecution execution, @Nonnull List<String> libraries) throws Exception;
+    public abstract @Nonnull List<Addition> add(@Nonnull CpsFlowExecution execution, @Nonnull List<String> libraries, @Nonnull HashMap<String, Boolean> changelogs) throws Exception;
 
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
@@ -105,6 +105,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowCopier;
             boolean kindTrusted = kind.isTrusted();
             for (LibraryConfiguration cfg : kind.forJob(build.getParent(), libraryVersions)) {
                 String name = cfg.getName();
+                boolean kindChangesets = cfg.getIncludeInChangesets();
                 if (!cfg.isImplicit() && !libraryVersions.containsKey(name)) {
                     continue; // not using this one at all
                 }
@@ -113,7 +114,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowCopier;
                     continue;
                 }
                 String version = cfg.defaultedVersion(libraryVersions.remove(name));
-                librariesAdded.put(name, new LibraryRecord(name, version, kindTrusted));
+                librariesAdded.put(name, new LibraryRecord(name, version, kindTrusted, kindChangesets));
                 retrievers.put(name, cfg.getRetriever());
             }
         }
@@ -128,7 +129,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowCopier;
         // Now actually try to retrieve the libraries.
         for (LibraryRecord record : librariesAdded.values()) {
             listener.getLogger().println("Loading library " + record.name + "@" + record.version);
-            for (URL u : retrieve(record.name, record.version, retrievers.get(record.name), record.trusted, listener, build, execution, record.variables)) {
+            for (URL u : retrieve(record.name, record.version, retrievers.get(record.name), record.trusted, record.changesets, listener, build, execution, record.variables)) {
                 additions.add(new Addition(u, record.trusted));
             }
         }
@@ -145,9 +146,9 @@ import org.jenkinsci.plugins.workflow.flow.FlowCopier;
     }
 
     /** Retrieve library files. */
-    static List<URL> retrieve(@Nonnull String name, @Nonnull String version, @Nonnull LibraryRetriever retriever, boolean trusted, @Nonnull TaskListener listener, @Nonnull Run<?,?> run, @Nonnull CpsFlowExecution execution, @Nonnull Set<String> variables) throws Exception {
+    static List<URL> retrieve(@Nonnull String name, @Nonnull String version, @Nonnull LibraryRetriever retriever, boolean trusted, boolean changesets, @Nonnull TaskListener listener, @Nonnull Run<?,?> run, @Nonnull CpsFlowExecution execution, @Nonnull Set<String> variables) throws Exception {
         FilePath libDir = new FilePath(execution.getOwner().getRootDir()).child("libs/" + name);
-        retriever.retrieve(name, version, libDir, run, listener);
+        retriever.retrieve(name, version, changesets, libDir, run, listener);
         // Replace any classes requested for replay:
         if (!trusted) {
             for (String clazz : ReplayAction.replacementsIn(execution)) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
@@ -196,9 +196,9 @@ import org.jenkinsci.plugins.workflow.flow.FlowCopier;
 
         // normalise changeset to make life easier
         if (changeset != null) {
-            if (changeset.matches("(changesets|true|yes)")) {
+            if (changeset.matches("^(changesets|true|yes)$")) {
                 changeset = "true";
-            } else if (changeset.matches("(nochangesets|false|no)")) {
+            } else if (changeset.matches("^(nochangesets|false|no)$")) {
                 changeset = "false";
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration.java
@@ -119,6 +119,16 @@ public class LibraryConfiguration extends AbstractDescribableImpl<LibraryConfigu
         this.includeInChangesets = includeInChangesets;
     }
 
+    @Nonnull boolean defaultedChangesets(@CheckForNull String changesets) throws AbortException {
+      if (changesets == null) {
+        return includeInChangesets;
+      }
+      if (!changesets.matches("(true|false)")) {
+        throw new AbortException("Only true, false or null are valid");
+      }
+      return Boolean.parseBoolean(changesets);
+    }
+
     @Nonnull String defaultedVersion(@CheckForNull String version) throws AbortException {
         if (version == null) {
             if (defaultVersion == null) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration.java
@@ -55,6 +55,7 @@ public class LibraryConfiguration extends AbstractDescribableImpl<LibraryConfigu
     private String defaultVersion;
     private boolean implicit;
     private boolean allowVersionOverride = true;
+    private boolean includeInChangesets = true;
 
     @DataBoundConstructor public LibraryConfiguration(String name, LibraryRetriever retriever) {
         this.name = name;
@@ -105,6 +106,17 @@ public class LibraryConfiguration extends AbstractDescribableImpl<LibraryConfigu
 
     @DataBoundSetter public void setAllowVersionOverride(boolean allowVersionOverride) {
         this.allowVersionOverride = allowVersionOverride;
+    }
+
+    /**
+     * Whether to include library changes in reported changes in a job {@link #getIncludeInChangesets}.
+     */
+    public boolean getIncludeInChangesets() {
+        return includeInChangesets;
+    }
+
+    @DataBoundSetter public void setIncludeInChangesets(boolean includeInChangesets) {
+        this.includeInChangesets = includeInChangesets;
     }
 
     @Nonnull String defaultedVersion(@CheckForNull String version) throws AbortException {

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration.java
@@ -80,7 +80,7 @@ public class LibraryConfiguration extends AbstractDescribableImpl<LibraryConfigu
     public String getDefaultVersion() {
         return defaultVersion;
     }
-    
+
     @DataBoundSetter public void setDefaultVersion(String defaultVersion) {
         this.defaultVersion = Util.fixEmpty(defaultVersion);
     }
@@ -119,14 +119,12 @@ public class LibraryConfiguration extends AbstractDescribableImpl<LibraryConfigu
         this.includeInChangesets = includeInChangesets;
     }
 
-    @Nonnull boolean defaultedChangesets(@CheckForNull String changesets) throws AbortException {
-      if (changesets == null) {
+    @Nonnull boolean defaultedChangelogs(@CheckForNull Boolean changelog) throws AbortException {
+      if (changelog == null) {
         return includeInChangesets;
+      } else {
+        return changelog;
       }
-      if (!changesets.matches("(true|false)")) {
-        throw new AbortException("Only true, false or null are valid");
-      }
-      return Boolean.parseBoolean(changesets);
     }
 
     @Nonnull String defaultedVersion(@CheckForNull String version) throws AbortException {

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRecord.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRecord.java
@@ -36,15 +36,17 @@ final class LibraryRecord {
     final String version;
     final Set<String> variables = new TreeSet<>();
     final boolean trusted;
+    final boolean changesets;
 
-    LibraryRecord(String name, String version, boolean trusted) {
+    LibraryRecord(String name, String version, boolean trusted, boolean changesets) {
         this.name = name;
         this.version = version;
         this.trusted = trusted;
+        this.changesets = changesets;
     }
 
     @Override public String toString() {
-        return "LibraryRecord{name=" + name + ", version=" + version + ", variables=" + variables + ", trusted=" + trusted + '}';
+        return "LibraryRecord{name=" + name + ", version=" + version + ", variables=" + variables + ", trusted=" + trusted + ", changesets=" + changesets + '}';
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRecord.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRecord.java
@@ -36,17 +36,17 @@ final class LibraryRecord {
     final String version;
     final Set<String> variables = new TreeSet<>();
     final boolean trusted;
-    final boolean changesets;
+    final boolean changelog;
 
-    LibraryRecord(String name, String version, boolean trusted, boolean changesets) {
+    LibraryRecord(String name, String version, boolean trusted, boolean changelog) {
         this.name = name;
         this.version = version;
         this.trusted = trusted;
-        this.changesets = changesets;
+        this.changelog = changelog;
     }
 
     @Override public String toString() {
-        return "LibraryRecord{name=" + name + ", version=" + version + ", variables=" + variables + ", trusted=" + trusted + ", changesets=" + changesets + '}';
+        return "LibraryRecord{name=" + name + ", version=" + version + ", variables=" + variables + ", trusted=" + trusted + ", changelog=" + changelog + '}';
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRetriever.java
@@ -42,12 +42,13 @@ public abstract class LibraryRetriever extends AbstractDescribableImpl<LibraryRe
      * Obtains library sources.
      * @param name the {@link LibraryConfiguration#getName}
      * @param version the version of the library, such as from {@link LibraryConfiguration#getDefaultVersion} or an override
+     * @param changesets whether to include changesets in the library in jobs using it from {@link LibraryConfiguration#getIncludeInChangesets}
      * @param target a directory in which to check out sources; should create {@code src/**}{@code /*.groovy} and/or {@code vars/*.groovy}, and optionally also {@code resources/}
      * @param run a build which will use the library
      * @param listener a way to report progress
      * @throws Exception if there is any problem (use {@link AbortException} for user errors)
      */
-    public abstract void retrieve(@Nonnull String name, @Nonnull String version, @Nonnull FilePath target, @Nonnull Run<?,?> run, @Nonnull TaskListener listener) throws Exception;
+    public abstract void retrieve(@Nonnull String name, @Nonnull String version, @Nonnull boolean changesets, @Nonnull FilePath target, @Nonnull Run<?,?> run, @Nonnull TaskListener listener) throws Exception;
 
     /**
      * Offer to validate a proposed {@code version} for {@link #retrieve}.

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRetriever.java
@@ -51,6 +51,17 @@ public abstract class LibraryRetriever extends AbstractDescribableImpl<LibraryRe
     public abstract void retrieve(@Nonnull String name, @Nonnull String version, @Nonnull boolean changesets, @Nonnull FilePath target, @Nonnull Run<?,?> run, @Nonnull TaskListener listener) throws Exception;
 
     /**
+     * Obtains library sources.
+     * @param name the {@link LibraryConfiguration#getName}
+     * @param version the version of the library, such as from {@link LibraryConfiguration#getDefaultVersion} or an override
+     * @param target a directory in which to check out sources; should create {@code src/**}{@code /*.groovy} and/or {@code vars/*.groovy}, and optionally also {@code resources/}
+     * @param run a build which will use the library
+     * @param listener a way to report progress
+     * @throws Exception if there is any problem (use {@link AbortException} for user errors)
+     */
+    public abstract void retrieve(@Nonnull String name, @Nonnull String version, @Nonnull FilePath target, @Nonnull Run<?,?> run, @Nonnull TaskListener listener) throws Exception;
+
+    /**
      * Offer to validate a proposed {@code version} for {@link #retrieve}.
      * @param name the proposed library name
      * @param version a proposed version

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRetriever.java
@@ -42,13 +42,13 @@ public abstract class LibraryRetriever extends AbstractDescribableImpl<LibraryRe
      * Obtains library sources.
      * @param name the {@link LibraryConfiguration#getName}
      * @param version the version of the library, such as from {@link LibraryConfiguration#getDefaultVersion} or an override
-     * @param changesets whether to include changesets in the library in jobs using it from {@link LibraryConfiguration#getIncludeInChangesets}
+     * @param changelog whether to include changesets in the library in jobs using it from {@link LibraryConfiguration#getIncludeInChangesets}
      * @param target a directory in which to check out sources; should create {@code src/**}{@code /*.groovy} and/or {@code vars/*.groovy}, and optionally also {@code resources/}
      * @param run a build which will use the library
      * @param listener a way to report progress
      * @throws Exception if there is any problem (use {@link AbortException} for user errors)
      */
-    public abstract void retrieve(@Nonnull String name, @Nonnull String version, @Nonnull boolean changesets, @Nonnull FilePath target, @Nonnull Run<?,?> run, @Nonnull TaskListener listener) throws Exception;
+    public abstract void retrieve(@Nonnull String name, @Nonnull String version, @Nonnull boolean changelog, @Nonnull FilePath target, @Nonnull Run<?,?> run, @Nonnull TaskListener listener) throws Exception;
 
     /**
      * Obtains library sources.

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryStep.java
@@ -152,9 +152,9 @@ public class LibraryStep extends AbstractStepImpl {
 
         @Override protected LoadedClasses run() throws Exception {
             String[] parsed = LibraryAdder.parse(step.identifier);
-            String name = parsed[0], version = parsed[1];
+            String name = parsed[0], version = parsed[1], changesetsParsed = parsed[2];
             boolean trusted = false;
-            boolean changesets = true;
+            boolean changesets = true; //initialise this but it will get overridden
             LibraryRetriever retriever = step.getRetriever();
             if (retriever == null) {
                 for (LibraryResolver resolver : ExtensionList.lookup(LibraryResolver.class)) {
@@ -163,7 +163,7 @@ public class LibraryStep extends AbstractStepImpl {
                             retriever = cfg.getRetriever();
                             trusted = resolver.isTrusted();
                             version = cfg.defaultedVersion(version);
-                            changesets = cfg.getIncludeInChangesets();
+                            changesets = cfg.defaultedChangesets(changesetsParsed);
                             break;
                         }
                     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMRetriever.java
@@ -64,6 +64,9 @@ public class SCMRetriever extends LibraryRetriever {
         SCMSourceRetriever.doRetrieve(name, changesets, scm, target, run, listener);
     }
 
+    @Override public void retrieve(String name, String version, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
+        SCMSourceRetriever.doRetrieve(name, true, scm, target, run, listener);
+    }
     @Override public FormValidation validateVersion(String name, String version) {
         if (!Items.XSTREAM2.toXML(scm).contains("${library." + name + ".version}")) {
             return FormValidation.warningWithMarkup("When using <b>" + getDescriptor().getDisplayName() + "</b>, you will need to include <code>${library." + Util.escape(name) + ".version}</code> in the SCM configuration somewhere.");

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMRetriever.java
@@ -60,8 +60,8 @@ public class SCMRetriever extends LibraryRetriever {
         return scm;
     }
 
-    @Override public void retrieve(String name, String version, boolean changesets, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
-        SCMSourceRetriever.doRetrieve(name, changesets, scm, target, run, listener);
+    @Override public void retrieve(String name, String version, boolean changelog, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
+        SCMSourceRetriever.doRetrieve(name, changelog, scm, target, run, listener);
     }
 
     @Override public void retrieve(String name, String version, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMRetriever.java
@@ -60,8 +60,8 @@ public class SCMRetriever extends LibraryRetriever {
         return scm;
     }
 
-    @Override public void retrieve(String name, String version, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
-        SCMSourceRetriever.doRetrieve(name, scm, target, run, listener);
+    @Override public void retrieve(String name, String version, boolean changesets, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
+        SCMSourceRetriever.doRetrieve(name, changesets, scm, target, run, listener);
     }
 
     @Override public FormValidation validateVersion(String name, String version) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
@@ -76,19 +76,19 @@ public class SCMSourceRetriever extends LibraryRetriever {
         return scm;
     }
 
-    @Override public void retrieve(String name, String version, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
+    @Override public void retrieve(String name, String version, boolean changesets, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
         SCMRevision revision = scm.fetch(version, listener);
         if (revision == null) {
             throw new AbortException("No version " + version + " found for library " + name);
         }
-        doRetrieve(name, scm.build(revision.getHead(), revision), target, run, listener);
+        doRetrieve(name, changesets, scm.build(revision.getHead(), revision), target, run, listener);
     }
 
-    static void doRetrieve(String name, @Nonnull SCM scm, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
+    static void doRetrieve(String name, boolean changesets, @Nonnull SCM scm, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
         // Adapted from CpsScmFlowDefinition:
         SCMStep delegate = new GenericSCMStep(scm);
         delegate.setPoll(false); // TODO we have no API for determining if a given SCMHead is branch-like or tag-like; would we want to turn on polling if the former?
-        delegate.setChangelog(true); // TODO is this desirable?
+        delegate.setChangelog(changesets);
         FilePath dir;
         Node node = Jenkins.getActiveInstance();
         if (run.getParent() instanceof TopLevelItem) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
@@ -76,23 +76,23 @@ public class SCMSourceRetriever extends LibraryRetriever {
         return scm;
     }
 
-    @Override public void retrieve(String name, String version, boolean changesets, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
+    @Override public void retrieve(String name, String version, boolean changelog, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
         SCMRevision revision = scm.fetch(version, listener);
         if (revision == null) {
             throw new AbortException("No version " + version + " found for library " + name);
         }
-        doRetrieve(name, changesets, scm.build(revision.getHead(), revision), target, run, listener);
+        doRetrieve(name, changelog, scm.build(revision.getHead(), revision), target, run, listener);
     }
 
     @Override public void retrieve(String name, String version, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
         retrieve(name, version, true, target, run, listener);
     }
 
-    static void doRetrieve(String name, boolean changesets, @Nonnull SCM scm, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
+    static void doRetrieve(String name, boolean changelog, @Nonnull SCM scm, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
         // Adapted from CpsScmFlowDefinition:
         SCMStep delegate = new GenericSCMStep(scm);
         delegate.setPoll(false); // TODO we have no API for determining if a given SCMHead is branch-like or tag-like; would we want to turn on polling if the former?
-        delegate.setChangelog(changesets);
+        delegate.setChangelog(changelog);
         FilePath dir;
         Node node = Jenkins.getActiveInstance();
         if (run.getParent() instanceof TopLevelItem) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
@@ -84,6 +84,10 @@ public class SCMSourceRetriever extends LibraryRetriever {
         doRetrieve(name, changesets, scm.build(revision.getHead(), revision), target, run, listener);
     }
 
+    @Override public void retrieve(String name, String version, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
+        retrieve(name, version, true, target, run, listener);
+    }
+
     static void doRetrieve(String name, boolean changesets, @Nonnull SCM scm, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
         // Adapted from CpsScmFlowDefinition:
         SCMStep delegate = new GenericSCMStep(scm);

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/config.jelly
@@ -37,5 +37,8 @@ THE SOFTWARE.
     <f:entry field="allowVersionOverride" title="${%Allow default version to be overridden}">
         <f:checkbox default="true"/>
     </f:entry>
+    <f:entry field="includeInChangesets" title="${%Include library changes in job changesets}">
+        <f:checkbox default="true"/>
+    </f:entry>
     <f:descriptorRadioList varName="retriever" instance="${instance.retriever}" descriptors="${descriptor.retrieverDescriptors}" title="${%Retrieval method}"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/config.jelly
@@ -37,7 +37,7 @@ THE SOFTWARE.
     <f:entry field="allowVersionOverride" title="${%Allow default version to be overridden}">
         <f:checkbox default="true"/>
     </f:entry>
-    <f:entry field="includeInChangesets" title="${%Include library changes in job changesets by default}">
+    <f:entry field="includeInChangesets" title="${%Include @Library changes in job recent changes}">
         <f:checkbox default="true"/>
     </f:entry>
     <f:descriptorRadioList varName="retriever" instance="${instance.retriever}" descriptors="${descriptor.retrieverDescriptors}" title="${%Retrieval method}"/>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/config.jelly
@@ -37,7 +37,7 @@ THE SOFTWARE.
     <f:entry field="allowVersionOverride" title="${%Allow default version to be overridden}">
         <f:checkbox default="true"/>
     </f:entry>
-    <f:entry field="includeInChangesets" title="${%Include library changes in job changesets}">
+    <f:entry field="includeInChangesets" title="${%Include library changes in job changesets by default}">
         <f:checkbox default="true"/>
     </f:entry>
     <f:descriptorRadioList varName="retriever" instance="${instance.retriever}" descriptors="${descriptor.retrieverDescriptors}" title="${%Retrieval method}"/>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/help-includeInChangesets.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/help-includeInChangesets.html
@@ -1,3 +1,6 @@
 <div>
-    If checked, any changes in the library will be included in the changesets of a build.
+  <p>If checked, any changes in the library will be included in the changesets of a build.
+  <p>This can be overridden in the jenkinsfile: name@version@changesets or name@version@nochangesets
+  <p>The argument can also be yes/no/true/false for the override.
+  <p>Just the changesets can be overridden by setting the version to null: mylibrary@null@changesets
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/help-includeInChangesets.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/help-includeInChangesets.html
@@ -1,6 +1,4 @@
 <div>
   <p>If checked, any changes in the library will be included in the changesets of a build.
-  <p>This can be overridden in the jenkinsfile: name@version@changesets or name@version@nochangesets
-  <p>The argument can also be yes/no/true/false for the override.
-  <p>Just the changesets can be overridden by setting the version to null: mylibrary@null@changesets
+  <p>This can be overridden in the jenkinsfile: @Library(value="name@version", changelog=true|false)
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/help-includeInChangesets.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/help-includeInChangesets.html
@@ -1,0 +1,3 @@
+<div>
+    If checked, any changes in the library will be included in the changesets of a build.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryStep/config.jelly
@@ -28,5 +28,8 @@ THE SOFTWARE.
     <f:entry field="identifier" title="${%Name and optional version}">
         <f:textbox/>
     </f:entry>
+    <f:entry field="changelog" title="${%Include recent changes in jobs}">
+        <f:checkbox default="true"/>
+    </f:entry>
     <f:descriptorRadioList varName="retriever" instance="${instance.retriever}" descriptors="${descriptor.retrieverDescriptors}" title="${%Retrieval method}"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryStep/help-changelog.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryStep/help-changelog.html
@@ -1,0 +1,5 @@
+<div>
+    Whether to include any changes in the shared library
+    in the recent changes of jobs using the library.
+    Defaults to including the changes.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
@@ -182,7 +182,7 @@ public class LibraryAdderTest {
         lc.setIncludeInChangesets(false);
         GlobalLibraries.get().setLibraries(Collections.singletonList(lc));
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("@Library('dont_include_changes@master@changesets') import myecho; myecho()", true));
+        p.setDefinition(new CpsFlowDefinition("@Library(value='dont_include_changes@master', changelog=true) import myecho; myecho()", true));
         FilePath base = r.jenkins.getWorkspaceFor(p).withSuffix("@libs").child("dont_include_changes");
         try (WorkspaceList.Lease lease = r.jenkins.toComputer().getWorkspaceList().acquire(base)) {
             WorkflowRun a = r.buildAndAssertSuccess(p);
@@ -215,7 +215,7 @@ public class LibraryAdderTest {
         lc.setIncludeInChangesets(true);
         GlobalLibraries.get().setLibraries(Collections.singletonList(lc));
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("@Library('include_changes@master@nochangesets') import myecho; myecho()", true));
+        p.setDefinition(new CpsFlowDefinition("@Library(value='include_changes@master', changelog=false) import myecho; myecho()", true));
         FilePath base = r.jenkins.getWorkspaceFor(p).withSuffix("@libs").child("include_changes");
         try (WorkspaceList.Lease lease = r.jenkins.toComputer().getWorkspaceList().acquire(base)) {
             WorkflowRun a = r.buildAndAssertSuccess(p);
@@ -229,41 +229,6 @@ public class LibraryAdderTest {
             assertEquals(0, changeSets.size());
         }
     }
-
-    @Issue("JENKINS-41497")
-    @Test public void onlyOverrideChangesets() throws Exception {
-        sampleRepo.init();
-        sampleRepo.write("vars/myecho.groovy", "def call() {echo 'something special'}");
-        sampleRepo.git("add", "vars");
-        sampleRepo.git("commit", "--message=init");
-        LibraryConfiguration lc = new LibraryConfiguration("dont_include_changes", new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)));
-        lc.setIncludeInChangesets(false);
-        lc.setDefaultVersion("master");
-        GlobalLibraries.get().setLibraries(Collections.singletonList(lc));
-        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("@Library('dont_include_changes@null@changesets') import myecho; myecho()", true));
-        FilePath base = r.jenkins.getWorkspaceFor(p).withSuffix("@libs").child("dont_include_changes");
-        try (WorkspaceList.Lease lease = r.jenkins.toComputer().getWorkspaceList().acquire(base)) {
-            WorkflowRun a = r.buildAndAssertSuccess(p);
-            r.assertLogContains("something special", a);
-        }
-        sampleRepo.write("vars/myecho.groovy", "def call() {echo 'something even more special'}");
-        sampleRepo.git("add", "vars");
-        sampleRepo.git("commit", "--message=shared_library_commit");
-        try (WorkspaceList.Lease lease = r.jenkins.toComputer().getWorkspaceList().acquire(base)) {
-            WorkflowRun b = r.buildAndAssertSuccess(p);
-            List<ChangeLogSet<? extends ChangeLogSet.Entry>> changeSets = b.getChangeSets();
-            assertEquals(1, changeSets.size());
-            ChangeLogSet<? extends ChangeLogSet.Entry> changeSet = changeSets.get(0);
-            assertEquals(b, changeSet.getRun());
-            assertEquals("git", changeSet.getKind());
-            Iterator<? extends ChangeLogSet.Entry> iterator = changeSet.iterator();
-            ChangeLogSet.Entry entry = iterator.next();
-            assertEquals("shared_library_commit", entry.getMsg() );
-            r.assertLogContains("something even more special", b);
-        }
-    }
-
 
     @Test public void globalVariable() throws Exception {
         sampleRepo.init();

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
@@ -25,6 +25,7 @@
 package org.jenkinsci.plugins.workflow.libs;
 
 import groovy.lang.MetaClass;
+import hudson.FilePath;
 import hudson.model.Job;
 import hudson.model.Result;
 import hudson.plugins.git.BranchSpec;
@@ -32,13 +33,16 @@ import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.SubmoduleConfig;
 import hudson.plugins.git.UserRemoteConfig;
 import hudson.plugins.git.extensions.GitSCMExtension;
+import hudson.slaves.WorkspaceList;
 import hudson.scm.SubversionSCM;
+import hudson.scm.ChangeLogSet;
 import java.lang.ref.WeakReference;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import jenkins.plugins.git.GitSCMSource;
@@ -167,6 +171,99 @@ public class LibraryAdderTest {
         p.setDefinition(new CpsFlowDefinition("@Library('stuff@trunk@" + tag + "') import pkg.Lib; echo(/using ${Lib.CONST}/)", true));
         r.assertLogContains("using initial", r.buildAndAssertSuccess(p));
     }
+
+    @Issue("JENKINS-41497")
+    @Test public void dontIncludeChangesetsOverriden() throws Exception {
+        sampleRepo.init();
+        sampleRepo.write("vars/myecho.groovy", "def call() {echo 'something special'}");
+        sampleRepo.git("add", "vars");
+        sampleRepo.git("commit", "--message=init");
+        LibraryConfiguration lc = new LibraryConfiguration("dont_include_changes", new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)));
+        lc.setIncludeInChangesets(false);
+        GlobalLibraries.get().setLibraries(Collections.singletonList(lc));
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("@Library('dont_include_changes@master@changesets') import myecho; myecho()", true));
+        FilePath base = r.jenkins.getWorkspaceFor(p).withSuffix("@libs").child("dont_include_changes");
+        try (WorkspaceList.Lease lease = r.jenkins.toComputer().getWorkspaceList().acquire(base)) {
+            WorkflowRun a = r.buildAndAssertSuccess(p);
+            r.assertLogContains("something special", a);
+        }
+        sampleRepo.write("vars/myecho.groovy", "def call() {echo 'something even more special'}");
+        sampleRepo.git("add", "vars");
+        sampleRepo.git("commit", "--message=shared_library_commit");
+        try (WorkspaceList.Lease lease = r.jenkins.toComputer().getWorkspaceList().acquire(base)) {
+            WorkflowRun b = r.buildAndAssertSuccess(p);
+            List<ChangeLogSet<? extends ChangeLogSet.Entry>> changeSets = b.getChangeSets();
+            assertEquals(1, changeSets.size());
+            ChangeLogSet<? extends ChangeLogSet.Entry> changeSet = changeSets.get(0);
+            assertEquals(b, changeSet.getRun());
+            assertEquals("git", changeSet.getKind());
+            Iterator<? extends ChangeLogSet.Entry> iterator = changeSet.iterator();
+            ChangeLogSet.Entry entry = iterator.next();
+            assertEquals("shared_library_commit", entry.getMsg() );
+            r.assertLogContains("something even more special", b);
+        }
+    }
+
+    @Issue("JENKINS-41497")
+    @Test public void includeChangesetsOverridden() throws Exception {
+        sampleRepo.init();
+        sampleRepo.write("vars/myecho.groovy", "def call() {echo 'something special'}");
+        sampleRepo.git("add", "vars");
+        sampleRepo.git("commit", "--message=init");
+        LibraryConfiguration lc = new LibraryConfiguration("include_changes", new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)));
+        lc.setIncludeInChangesets(true);
+        GlobalLibraries.get().setLibraries(Collections.singletonList(lc));
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("@Library('include_changes@master@nochangesets') import myecho; myecho()", true));
+        FilePath base = r.jenkins.getWorkspaceFor(p).withSuffix("@libs").child("include_changes");
+        try (WorkspaceList.Lease lease = r.jenkins.toComputer().getWorkspaceList().acquire(base)) {
+            WorkflowRun a = r.buildAndAssertSuccess(p);
+        }
+        sampleRepo.write("vars/myecho.groovy", "def call() {echo 'something even more special'}");
+        sampleRepo.git("add", "vars");
+        sampleRepo.git("commit", "--message=shared_library_commit");
+        try (WorkspaceList.Lease lease = r.jenkins.toComputer().getWorkspaceList().acquire(base)) {
+            WorkflowRun b = r.buildAndAssertSuccess(p);
+            List<ChangeLogSet<? extends ChangeLogSet.Entry>> changeSets = b.getChangeSets();
+            assertEquals(0, changeSets.size());
+        }
+    }
+
+    @Issue("JENKINS-41497")
+    @Test public void onlyOverrideChangesets() throws Exception {
+        sampleRepo.init();
+        sampleRepo.write("vars/myecho.groovy", "def call() {echo 'something special'}");
+        sampleRepo.git("add", "vars");
+        sampleRepo.git("commit", "--message=init");
+        LibraryConfiguration lc = new LibraryConfiguration("dont_include_changes", new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)));
+        lc.setIncludeInChangesets(false);
+        lc.setDefaultVersion("master");
+        GlobalLibraries.get().setLibraries(Collections.singletonList(lc));
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("@Library('dont_include_changes@null@changesets') import myecho; myecho()", true));
+        FilePath base = r.jenkins.getWorkspaceFor(p).withSuffix("@libs").child("dont_include_changes");
+        try (WorkspaceList.Lease lease = r.jenkins.toComputer().getWorkspaceList().acquire(base)) {
+            WorkflowRun a = r.buildAndAssertSuccess(p);
+            r.assertLogContains("something special", a);
+        }
+        sampleRepo.write("vars/myecho.groovy", "def call() {echo 'something even more special'}");
+        sampleRepo.git("add", "vars");
+        sampleRepo.git("commit", "--message=shared_library_commit");
+        try (WorkspaceList.Lease lease = r.jenkins.toComputer().getWorkspaceList().acquire(base)) {
+            WorkflowRun b = r.buildAndAssertSuccess(p);
+            List<ChangeLogSet<? extends ChangeLogSet.Entry>> changeSets = b.getChangeSets();
+            assertEquals(1, changeSets.size());
+            ChangeLogSet<? extends ChangeLogSet.Entry> changeSet = changeSets.get(0);
+            assertEquals(b, changeSet.getRun());
+            assertEquals("git", changeSet.getKind());
+            Iterator<? extends ChangeLogSet.Entry> iterator = changeSet.iterator();
+            ChangeLogSet.Entry entry = iterator.next();
+            assertEquals("shared_library_commit", entry.getMsg() );
+            r.assertLogContains("something even more special", b);
+        }
+    }
+
 
     @Test public void globalVariable() throws Exception {
         sampleRepo.init();

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryDecoratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryDecoratorTest.java
@@ -29,6 +29,7 @@ import hudson.model.Result;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.HashMap;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
@@ -64,7 +65,7 @@ public class LibraryDecoratorTest {
     }
 
     @TestExtension public static class TestAdder extends ClasspathAdder {
-        @Override public List<Addition> add(CpsFlowExecution execution, List<String> libraries) throws Exception {
+        @Override public List<Addition> add(CpsFlowExecution execution, List<String> libraries, HashMap<String, Boolean> changelogs) throws Exception {
             List<Addition> additions = new ArrayList<>();
             for (String library : libraries) {
                 additions.add(new Addition(new File(((WorkflowRun) execution.getOwner().getExecutable()).getParent().getRootDir(), "libs/" + library).toURI().toURL(), false));
@@ -97,7 +98,7 @@ public class LibraryDecoratorTest {
         r.assertLogContains("failed to load [stuff]", r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0)));
     }
     @TestExtension("adderError") public static class ErroneousAdder extends ClasspathAdder {
-        @Override public List<Addition> add(CpsFlowExecution execution, List<String> libraries) throws Exception {
+        @Override public List<Addition> add(CpsFlowExecution execution, List<String> libraries, HashMap<String, Boolean> changelogs) throws Exception {
             throw new AbortException("failed to load " + libraries);
         }
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryStepTest.java
@@ -67,13 +67,15 @@ public class LibraryStepTest {
         snippetizerTester.assertRoundTrip(s, "library 'foo'");
         s = new LibraryStep("foo@master");
         s.setRetriever(new SCMSourceRetriever(new GitSCMSource("id", "https://nowhere.net/", "", "origin", "+refs/heads/*:refs/remotes/origin/*", "*", "", true)));
+        s.setChangelog(true);
         r.assertEqualDataBoundBeans(s, stepTester.configRoundTrip(s));
         snippetizerTester.assertRoundTrip(s, "library identifier: 'foo@master', retriever: modernSCM([$class: 'GitSCMSource', credentialsId: '', excludes: '', id: 'id', ignoreOnPushNotifications: true, includes: '*', rawRefSpecs: '+refs/heads/*:refs/remotes/origin/*', remote: 'https://nowhere.net/', remoteName: 'origin'])");
         s.setRetriever(new SCMRetriever(new GitSCM(Collections.singletonList(new UserRemoteConfig("https://nowhere.net/", null, null, null)),
             Collections.singletonList(new BranchSpec("${library.foo.version}")),
             false, Collections.<SubmoduleConfig>emptyList(), null, null, Collections.<GitSCMExtension>emptyList())));
+        s.setChangelog(false);
         r.assertEqualDataBoundBeans(s, stepTester.configRoundTrip(s));
-        snippetizerTester.assertRoundTrip(s, "library identifier: 'foo@master', retriever: legacySCM([$class: 'GitSCM', branches: [[name: '${library.foo.version}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://nowhere.net/']]])");
+        snippetizerTester.assertRoundTrip(s, "library changelog: false, identifier: 'foo@master', retriever: legacySCM([$class: 'GitSCM', branches: [[name: '${library.foo.version}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://nowhere.net/']]])");
     }
 
     @Test public void vars() throws Exception {
@@ -88,13 +90,13 @@ public class LibraryStepTest {
         r.assertLogContains("ran library", b);
         LibrariesAction action = b.getAction(LibrariesAction.class);
         assertNotNull(action);
-        assertEquals("[LibraryRecord{name=stuff, version=master, variables=[x], trusted=true, changesets=true}]", action.getLibraries().toString());
-        p.setDefinition(new CpsFlowDefinition("library identifier: 'otherstuff@master', retriever: modernSCM([$class: 'GitSCMSource', remote: $/" + sampleRepo + "/$, credentialsId: '']); x()", true));
+        assertEquals("[LibraryRecord{name=stuff, version=master, variables=[x], trusted=true, changelog=true}]", action.getLibraries().toString());
+        p.setDefinition(new CpsFlowDefinition("library identifier: 'otherstuff@master', retriever: modernSCM([$class: 'GitSCMSource', remote: $/" + sampleRepo + "/$, credentialsId: '']), changelog: false; x()", true));
         b = r.buildAndAssertSuccess(p);
         r.assertLogContains("ran library", b);
         action = b.getAction(LibrariesAction.class);
         assertNotNull(action);
-        assertEquals("[LibraryRecord{name=otherstuff, version=master, variables=[x], trusted=false, changesets=true}]", action.getLibraries().toString());
+        assertEquals("[LibraryRecord{name=otherstuff, version=master, variables=[x], trusted=false, changelog=false}]", action.getLibraries().toString());
     }
 
     @Test public void classes() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryStepTest.java
@@ -88,13 +88,13 @@ public class LibraryStepTest {
         r.assertLogContains("ran library", b);
         LibrariesAction action = b.getAction(LibrariesAction.class);
         assertNotNull(action);
-        assertEquals("[LibraryRecord{name=stuff, version=master, variables=[x], trusted=true}]", action.getLibraries().toString());
+        assertEquals("[LibraryRecord{name=stuff, version=master, variables=[x], trusted=true, changesets=true}]", action.getLibraries().toString());
         p.setDefinition(new CpsFlowDefinition("library identifier: 'otherstuff@master', retriever: modernSCM([$class: 'GitSCMSource', remote: $/" + sampleRepo + "/$, credentialsId: '']); x()", true));
         b = r.buildAndAssertSuccess(p);
         r.assertLogContains("ran library", b);
         action = b.getAction(LibrariesAction.class);
         assertNotNull(action);
-        assertEquals("[LibraryRecord{name=otherstuff, version=master, variables=[x], trusted=false}]", action.getLibraries().toString());
+        assertEquals("[LibraryRecord{name=otherstuff, version=master, variables=[x], trusted=false, changesets=true}]", action.getLibraries().toString());
     }
 
     @Test public void classes() throws Exception {

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetrieverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetrieverTest.java
@@ -69,6 +69,7 @@ public class SCMSourceRetrieverTest {
         }
     }
 
+    @Issue("JENKINS-41497")
     @Test public void includeChanges() throws Exception {
         sampleRepo.init();
         sampleRepo.write("vars/myecho.groovy", "def call() {echo 'something special'}");
@@ -101,6 +102,7 @@ public class SCMSourceRetrieverTest {
         }
     }
 
+    @Issue("JENKINS-41497")
     @Test public void dontIncludeChanges() throws Exception {
         sampleRepo.init();
         sampleRepo.write("vars/myecho.groovy", "def call() {echo 'something special'}");

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetrieverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetrieverTest.java
@@ -26,12 +26,15 @@ package org.jenkinsci.plugins.workflow.libs;
 
 import hudson.FilePath;
 import hudson.slaves.WorkspaceList;
+import java.util.List;
+import java.util.Iterator;
 import java.util.Collections;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import hudson.scm.ChangeLogSet;
 import org.junit.ClassRule;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -66,4 +69,59 @@ public class SCMSourceRetrieverTest {
         }
     }
 
+    @Test public void includeChanges() throws Exception {
+        sampleRepo.init();
+        sampleRepo.write("vars/myecho.groovy", "def call() {echo 'something special'}");
+        sampleRepo.git("add", "vars");
+        sampleRepo.git("commit", "--message=init");
+        GlobalLibraries.get().setLibraries(Collections.singletonList(
+            new LibraryConfiguration("include_changes",
+                new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)))));
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("@Library('include_changes@master') import myecho; myecho()", true));
+        FilePath base = r.jenkins.getWorkspaceFor(p).withSuffix("@libs").child("include_changes");
+        try (WorkspaceList.Lease lease = r.jenkins.toComputer().getWorkspaceList().acquire(base)) {
+            WorkflowRun a = r.buildAndAssertSuccess(p);
+            r.assertLogContains("something special", a);
+        }
+        sampleRepo.write("vars/myecho.groovy", "def call() {echo 'something even more special'}");
+        sampleRepo.git("add", "vars");
+        sampleRepo.git("commit", "--message=shared_library_commit");
+        try (WorkspaceList.Lease lease = r.jenkins.toComputer().getWorkspaceList().acquire(base)) {
+            WorkflowRun b = r.buildAndAssertSuccess(p);
+            List<ChangeLogSet<? extends ChangeLogSet.Entry>> changeSets = b.getChangeSets();
+            assertEquals(1, changeSets.size());
+            ChangeLogSet<? extends ChangeLogSet.Entry> changeSet = changeSets.get(0);
+            assertEquals(b, changeSet.getRun());
+            assertEquals("git", changeSet.getKind());
+            Iterator<? extends ChangeLogSet.Entry> iterator = changeSet.iterator();
+            ChangeLogSet.Entry entry = iterator.next();
+            assertEquals("shared_library_commit", entry.getMsg() );
+            r.assertLogContains("something even more special", b);
+        }
+    }
+
+    @Test public void dontIncludeChanges() throws Exception {
+        sampleRepo.init();
+        sampleRepo.write("vars/myecho.groovy", "def call() {echo 'something special'}");
+        sampleRepo.git("add", "vars");
+        sampleRepo.git("commit", "--message=init");
+        LibraryConfiguration lc = new LibraryConfiguration("dont_include_changes", new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)));
+        lc.setIncludeInChangesets(false);
+        GlobalLibraries.get().setLibraries(Collections.singletonList(lc));
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("@Library('dont_include_changes@master') import myecho; myecho()", true));
+        FilePath base = r.jenkins.getWorkspaceFor(p).withSuffix("@libs").child("dont_include_changes");
+        try (WorkspaceList.Lease lease = r.jenkins.toComputer().getWorkspaceList().acquire(base)) {
+            WorkflowRun a = r.buildAndAssertSuccess(p);
+        }
+        sampleRepo.write("vars/myecho.groovy", "def call() {echo 'something even more special'}");
+        sampleRepo.git("add", "vars");
+        sampleRepo.git("commit", "--message=shared_library_commit");
+        try (WorkspaceList.Lease lease = r.jenkins.toComputer().getWorkspaceList().acquire(base)) {
+            WorkflowRun b = r.buildAndAssertSuccess(p);
+            List<ChangeLogSet<? extends ChangeLogSet.Entry>> changeSets = b.getChangeSets();
+            assertEquals(0, changeSets.size());
+        }
+    }
 }


### PR DESCRIPTION
[JENKINS-41497](https://issues.jenkins-ci.org/browse/JENKINS-41497)

Although it can be useful to see what changes in a shared library could have an impact on a build there are many circumstances that shared library commits should be ignored.

This provides a configuration option to skip adding the changeset of a shared library to a build.

It defaults to including the changeset to match the current behaviour.
