### PR TITLE
Add programmatic configuration for plugin

### DIFF
--- a/config-workflow-cps-global-lib-plugin.groovy
+++ b/config-workflow-cps-global-lib-plugin.groovy
@@ -1,0 +1,29 @@
+import jenkins.model.*;
+import jenkins.plugins.git.*;
+import org.jenkinsci.plugins.workflow.libs.*;
+
+def inst = Jenkins.getInstance()
+def descriptor = inst.getDescriptorByType(org.jenkinsci.plugins.workflow.libs.GlobalLibraries)
+
+scm = new GitSCMSource(
+  'name-of-library',                            // String id
+  'git@github.com:owner/jenkins-libraries.git', // String remote
+  'github-ssh-key',                             // String credentialsId
+  'origin',                                     // String remoteName
+  '+refs/heads/*:refs/remotes/origin/*',        // String rawRefSpecs
+  '*',                                          // String includes
+  '',                                           // String excludes
+  false                                         // booleean ignoreOnPushNotifications
+)
+
+retriever = new SCMSourceRetriever(scm)
+
+libConfig = new LibraryConfiguration("jenkins-libraries", retriever)
+libConfig.setDefaultVersion('master')
+libConfig.setImplicit(true)
+libConfig.setAllowVersionOverride(true)
+
+libraries = []
+libraries << libConfig
+
+descriptor.setLibraries(libraries)


### PR DESCRIPTION
This change adds a groovy script that can be used in the
Jenkins init system to configure the plugin without
using the UI.

@jglick not sure if this is the right place for this (or if you folks have interest). Let me know your thoughts :)