### PR TITLE
Updates for PCT

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, '2.60.3', '2.73.1'])
+buildPlugin(jenkinsVersions: [null, '2.60.3', '2.89'])

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <jenkins.version>2.7.3</jenkins.version>
         <java.level>7</java.level>
         <workflow-cps-plugin.version>2.39</workflow-cps-plugin.version>
-        <git-plugin.version>3.6.5-20171201.030040-1</git-plugin.version> <!-- TODO https://github.com/jenkinsci/git-plugin/pull/557 -->
+        <git-plugin.version>3.6.4</git-plugin.version>
         <scm-api-plugin.version>2.2.5</scm-api-plugin.version>
         <workflow-scm-step-plugin.version>2.4</workflow-scm-step-plugin.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.1</version>
+        <version>3.2-20171201.034402-1</version> <!-- TODO https://github.com/jenkinsci/plugin-pom/pull/91 -->
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -189,6 +189,12 @@
             <artifactId>git</artifactId>
             <version>${git-plugin.version}</version>
             <scope>test</scope>
+            <exclusions> <!-- TODO possibly bug in git-plugin/pom.xml -->
+                <exclusion>
+                    <groupId>org.jenkins-ci</groupId>
+                    <artifactId>annotation-indexer</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -196,6 +202,12 @@
             <version>${git-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jenkins-ci</groupId>
+                    <artifactId>annotation-indexer</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -241,4 +241,15 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <reuseForks>false</reuseForks> <!-- TODO reuse seems to cause problems in LibraryMemoryTest -->
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.33</version>
+        <version>3.1</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -36,11 +36,11 @@
     <version>2.10-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Shared Groovy Libraries</name>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Shared+Groovy+Libraries+Plugin</url>
+    <url>https://wiki.jenkins.io/display/JENKINS/Pipeline+Shared+Groovy+Libraries+Plugin</url>
     <licenses>
         <license>
             <name>MIT License</name>
-            <url>http://opensource.org/licenses/MIT</url>
+            <url>https://opensource.org/licenses/MIT</url>
         </license>
     </licenses>
     <scm>
@@ -63,9 +63,10 @@
     </pluginRepositories>
     <properties>
         <jenkins.version>2.7.3</jenkins.version>
+        <java.level>7</java.level>
         <workflow-cps-plugin.version>2.39</workflow-cps-plugin.version>
-        <git-plugin.version>3.1.0</git-plugin.version>
-        <scm-api-plugin.version>2.1.1</scm-api-plugin.version>
+        <git-plugin.version>3.6.5-20171201.030040-1</git-plugin.version> <!-- TODO https://github.com/jenkinsci/git-plugin/pull/557 -->
+        <scm-api-plugin.version>2.2.5</scm-api-plugin.version>
         <workflow-scm-step-plugin.version>2.4</workflow-scm-step-plugin.version>
     </properties>
     <dependencies>
@@ -88,7 +89,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git-client</artifactId>
-            <version>2.3.0</version> <!-- do not pick up an obsolete version from git-server -->
+            <version>2.6.0</version> <!-- do not pick up an obsolete version from git-server -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -109,6 +110,16 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
             <version>1.33</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>structs</artifactId>
+            <version>1.10</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>credentials</artifactId>
+            <version>2.1.14</version>
         </dependency>
         <dependency>
             <groupId>org.apache.ivy</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.2-20171201.034402-1</version> <!-- TODO https://github.com/jenkinsci/plugin-pom/pull/91 -->
+        <version>3.2</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
@@ -24,7 +24,6 @@
 
 package org.jenkinsci.plugins.workflow.libs;
 
-import groovy.lang.MetaClass;
 import hudson.FilePath;
 import hudson.model.Job;
 import hudson.model.Result;
@@ -36,10 +35,6 @@ import hudson.plugins.git.extensions.GitSCMExtension;
 import hudson.slaves.WorkspaceList;
 import hudson.scm.SubversionSCM;
 import hudson.scm.ChangeLogSet;
-import java.lang.ref.WeakReference;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -49,8 +44,6 @@ import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
 import jenkins.scm.impl.subversion.SubversionSCMSource;
 import jenkins.scm.impl.subversion.SubversionSampleRepoRule;
-import org.codehaus.groovy.reflection.ClassInfo;
-import org.codehaus.groovy.transform.ASTTransformationVisitor;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.cps.GlobalVariable;
 import org.jenkinsci.plugins.workflow.cps.global.GrapeTest;
@@ -65,7 +58,6 @@ import org.junit.Rule;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.jvnet.hudson.test.MemoryAssert;
 import org.jvnet.hudson.test.TestExtension;
 
 public class LibraryAdderTest {
@@ -324,38 +316,6 @@ public class LibraryAdderTest {
         WorkflowRun b2 = (WorkflowRun) ra.run(ra.getOriginalScript(), Collections.singletonMap("trusted", originalScript.replace(originalMessage, "should not allowed"))).get();
         r.assertBuildStatusSuccess(b2); // currently do not throw an error, since the GUI does not offer it anyway
         r.assertLogContains(originalMessage, b2);
-    }
-
-    private static final List<WeakReference<ClassLoader>> LOADERS = new ArrayList<>();
-    public static void register(Object o) {
-        ClassLoader loader = o.getClass().getClassLoader();
-        System.err.println("registering " + o + " from " + loader);
-        LOADERS.add(new WeakReference<>(loader));
-    }
-    @Test public void loaderReleased() throws Exception {
-        sampleRepo.init();
-        sampleRepo.write("vars/leak.groovy", "def call() {" + LibraryAdderTest.class.getName() + ".register(this)}");
-        sampleRepo.git("add", "vars");
-        sampleRepo.git("commit", "--message=init");
-        GlobalLibraries.get().setLibraries(Collections.singletonList(new LibraryConfiguration("leak", new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)))));
-        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("@Library('leak@master') _; " + LibraryAdderTest.class.getName() + ".register(this); leak()", false));
-        r.assertBuildStatusSuccess(p.scheduleBuild2(0));
-        assertFalse(LOADERS.isEmpty());
-        try { // For Jenkins/Groovy 1. Cf. CpsFlowExecutionTest.loaderReleased.
-            Field f = ASTTransformationVisitor.class.getDeclaredField("compUnit");
-            f.setAccessible(true);
-            f.set(null, null);
-        } catch (NoSuchFieldException e) {}
-        { // ditto
-            MetaClass metaClass = ClassInfo.getClassInfo(LibraryAdderTest.class).getMetaClass();
-            Method clearInvocationCaches = metaClass.getClass().getDeclaredMethod("clearInvocationCaches");
-            clearInvocationCaches.setAccessible(true);
-            clearInvocationCaches.invoke(metaClass);
-        }
-        for (WeakReference<ClassLoader> loaderRef : LOADERS) {
-            MemoryAssert.assertGC(loaderRef, false);
-        }
     }
 
     @Issue({"JENKINS-38021", "JENKINS-31484"})

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryMemoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryMemoryTest.java
@@ -1,0 +1,79 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2017 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.libs;
+
+import groovy.lang.MetaClass;
+import java.lang.ref.WeakReference;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import jenkins.plugins.git.GitSCMSource;
+import jenkins.plugins.git.GitSampleRepoRule;
+import org.codehaus.groovy.reflection.ClassInfo;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import static org.junit.Assert.assertFalse;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MemoryAssert;
+
+public class LibraryMemoryTest {
+
+    @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
+    @Rule public JenkinsRule r = new JenkinsRule();
+    @Rule public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
+
+    private static final List<WeakReference<ClassLoader>> LOADERS = new ArrayList<>();
+    public static void register(Object o) {
+        ClassLoader loader = o.getClass().getClassLoader();
+        System.err.println("registering " + o + " from " + loader);
+        LOADERS.add(new WeakReference<>(loader));
+    }
+    @Test public void loaderReleased() throws Exception {
+        sampleRepo.init();
+        sampleRepo.write("vars/leak.groovy", "def call() {" + LibraryMemoryTest.class.getName() + ".register(this)}");
+        sampleRepo.git("add", "vars");
+        sampleRepo.git("commit", "--message=init");
+        GlobalLibraries.get().setLibraries(Collections.singletonList(new LibraryConfiguration("leak", new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)))));
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("@Library('leak@master') _; " + LibraryMemoryTest.class.getName() + ".register(this); leak()", false));
+        r.assertBuildStatusSuccess(p.scheduleBuild2(0));
+        assertFalse(LOADERS.isEmpty());
+        { // cf. CpsFlowExecutionMemoryTest
+            MetaClass metaClass = ClassInfo.getClassInfo(LibraryMemoryTest.class).getMetaClass();
+            Method clearInvocationCaches = metaClass.getClass().getDeclaredMethod("clearInvocationCaches");
+            clearInvocationCaches.setAccessible(true);
+            clearInvocationCaches.invoke(metaClass);
+        }
+        for (WeakReference<ClassLoader> loaderRef : LOADERS) {
+            MemoryAssert.assertGC(loaderRef, false);
+        }
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryStepTest.java
@@ -69,7 +69,7 @@ public class LibraryStepTest {
         s.setRetriever(new SCMSourceRetriever(new GitSCMSource("id", "https://nowhere.net/", "", "origin", "+refs/heads/*:refs/remotes/origin/*", "*", "", true)));
         s.setChangelog(true);
         r.assertEqualDataBoundBeans(s, stepTester.configRoundTrip(s));
-        snippetizerTester.assertRoundTrip(s, "library identifier: 'foo@master', retriever: modernSCM([$class: 'GitSCMSource', credentialsId: '', excludes: '', id: 'id', ignoreOnPushNotifications: true, includes: '*', rawRefSpecs: '+refs/heads/*:refs/remotes/origin/*', remote: 'https://nowhere.net/', remoteName: 'origin'])");
+        snippetizerTester.assertRoundTrip(s, "library identifier: 'foo@master', retriever: modernSCM([$class: 'GitSCMSource', credentialsId: '', id: 'id', remote: 'https://nowhere.net/', traits: [[$class: 'BranchDiscoveryTrait'], [$class: 'IgnoreOnPushNotificationTrait']]])");
         s.setRetriever(new SCMRetriever(new GitSCM(Collections.singletonList(new UserRemoteConfig("https://nowhere.net/", null, null, null)),
             Collections.singletonList(new BranchSpec("${library.foo.version}")),
             false, Collections.<SubmoduleConfig>emptyList(), null, null, Collections.<GitSCMExtension>emptyList())));

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/ResourceStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/ResourceStepTest.java
@@ -68,14 +68,13 @@ public class ResourceStepTest {
         sampleRepo.write("resources/pkg/file", "initial contents");
         sampleRepo.git("add", "src", "resources");
         sampleRepo.git("commit", "--message=init");
-        String v1 = sampleRepo.head();
+        sampleRepo.git("tag", "v1");
         sampleRepo.write("resources/pkg/file", "subsequent contents");
         sampleRepo.git("commit", "--all", "--message=edited");
-        String v2 = sampleRepo.head();
         LibraryConfiguration stuff1 = new LibraryConfiguration("stuff1", new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)));
-        stuff1.setDefaultVersion(v1);
+        stuff1.setDefaultVersion("v1");
         LibraryConfiguration stuff2 = new LibraryConfiguration("stuff2", new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)));
-        stuff2.setDefaultVersion(v2);
+        stuff2.setDefaultVersion("master");
         GlobalLibraries.get().setLibraries(Arrays.asList(stuff1, stuff2));
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("@Library(['stuff1', 'stuff2']) import pkg.Stuff; echo(/got ${Stuff.contents(this)}/)", true));


### PR DESCRIPTION
Fixes some test regressions detected by PCT.

```
org.junit.ComparisonFailure: expected:<... credentialsId: '', [excludes: '', id: 'id', ignoreOnPushNotifications: true, includes: '*', rawRefSpecs: '+refs/heads/*:refs/remotes/origin/*', remote: 'https://nowhere.net/', remoteName: 'origin']])> but was:<... credentialsId: '', [id: 'id', remote: 'https://nowhere.net/', traits: [[$class: 'BranchDiscoveryTrait'], [$class: 'IgnoreOnPushNotificationTrait']]]])>
	at org.junit.Assert.assertEquals(Assert.java:115)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at org.jenkinsci.plugins.workflow.cps.SnippetizerTester.assertRoundTrip(SnippetizerTester.java:95)
	at org.jenkinsci.plugins.workflow.libs.LibraryStepTest.configRoundtrip(LibraryStepTest.java:72)

Expected: a string containing "Library resource pkg/file ambiguous among libraries [stuff1, stuff2]"
     but: was "Started
Loading library stuff1@e3036e88ab4018d20d62eccf1f3f807a9ea95f4d
Attempting to resolve e3036e88ab4018d20d62eccf1f3f807a9ea95f4d from remote references...
…
 > git branch -v --no-abbrev --contains e3036e88ab4018d20d62eccf1f3f807a9ea95f4d # timeout=10
Could not find a branch containing commit e3036e88ab4018d20d62eccf1f3f807a9ea95f4d
ERROR: No version e3036e88ab4018d20d62eccf1f3f807a9ea95f4d found for library stuff1
org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
WorkflowScript: Loading libraries failed
```

@reviewbybees