### PR TITLE
Fix retry problem on library step

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <jenkins.version>2.7.3</jenkins.version>
+        <jenkins.version>2.60.3</jenkins.version>
         <java.level>7</java.level>
         <workflow-cps-plugin.version>2.39</workflow-cps-plugin.version>
         <git-plugin.version>3.6.4</git-plugin.version>

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryStep.java
@@ -186,10 +186,7 @@ public class LibraryStep extends AbstractStepImpl {
 
             LibraryRecord record = new LibraryRecord(name, version, trusted, changelog);
             LibrariesAction action = run.getAction(LibrariesAction.class);
-            if (action == null) {
-                action = new LibrariesAction(Lists.newArrayList(record));
-                run.addAction(action);
-            } else {
+            if (action != null) {
                 List<LibraryRecord> libraries = action.getLibraries();
                 for (LibraryRecord existing : libraries) {
                     if (existing.name.equals(name)) {
@@ -197,13 +194,18 @@ public class LibraryStep extends AbstractStepImpl {
                         return new LoadedClasses(name, trusted, changelog, run);
                     }
                 }
-                libraries.add(record);
             }
             listener.getLogger().println("Loading library " + record.name + "@" + record.version);
             CpsFlowExecution exec = (CpsFlowExecution) getContext().get(FlowExecution.class);
             GroovyClassLoader loader = (trusted ? exec.getTrustedShell() : exec.getShell()).getClassLoader();
             for (URL u : LibraryAdder.retrieve(record.name, record.version, retriever, record.trusted, record.changelog, listener, run, (CpsFlowExecution) getContext().get(FlowExecution.class), record.variables)) {
                 loader.addURL(u);
+            }
+            if (action == null) {
+                action = new LibrariesAction(Lists.newArrayList(record));
+                run.addAction(action);
+            } else {
+            	action.getLibraries().add(record);
             }
             run.save(); // persist changes to LibrariesAction.libraries*.variables
             return new LoadedClasses(name, trusted, changelog, run);


### PR DESCRIPTION
I have observed an intermittent failure fetching library from SCM in a random job about once a day.
So i tried to do a retry like this:
```
retry(3){
    library identifier: "my-library@master"
}
```
But when i do this, i have this error:
```
[Pipeline] retry
[Pipeline] {
[Pipeline] library
Loading library my-library@master
...
[Pipeline] }
ERROR: Execution failed
hudson.plugins.git.GitException: Command "git.exe ls-remote ... returned status code 128:
...
Retrying
[Pipeline] {
[Pipeline] library
Only using first definition of library my-library
[Pipeline] }
[Pipeline] // retry
[Pipeline] End of Pipeline
java.lang.NoSuchMethodError: No such DSL method 'methodInMyLibrary' found among steps
```
If there is an error on first attempt, second retry don't reload the library (`Only using first definition of library my-library`).

This pull request fixes this problem.