### PR TITLE
feat: retry checkout of global pipeline library

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
@@ -28,6 +28,7 @@ import hudson.AbortException;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.FilePath;
+import hudson.Functions;
 import hudson.Util;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
@@ -41,6 +42,7 @@ import hudson.slaves.WorkspaceList;
 import hudson.util.FormValidation;
 import hudson.util.StreamTaskListener;
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -109,7 +111,32 @@ public class SCMSourceRetriever extends LibraryRetriever {
             throw new IOException(node.getDisplayName() + " may be offline");
         }
         try (WorkspaceList.Lease lease = computer.getWorkspaceList().allocate(dir)) {
-            delegate.checkout(run, lease.path, listener, node.createLauncher(listener));
+            for (int retryCount = Jenkins.getInstance().getScmCheckoutRetryCount(); retryCount >= 0; retryCount--) {
+                try {
+                    delegate.checkout(run, lease.path, listener, node.createLauncher(listener));
+                    break;
+                }
+                catch (AbortException e) {
+                    // abort exception might have a null message.
+                    // If so, just skip echoing it.
+                    if (e.getMessage() != null) {
+                        listener.error(e.getMessage());
+                    }
+                }
+                catch (InterruptedIOException e) {
+                    throw e;
+                }
+                catch (IOException e) {
+                    // checkout error not yet reported
+                    listener.error("Checkout failed").println(Functions.printThrowable(e).trim()); // TODO 2.43+ use Functions.printStackTrace
+                }
+
+                if (retryCount == 0)   // all attempts failed
+                    throw new AbortException("Maximum checkout retry attempts reached, aborting");
+
+                listener.getLogger().println("Retrying after 10 seconds");
+                Thread.sleep(10000);
+            }
             // Cannot add WorkspaceActionImpl to private CpsFlowExecution.flowStartNodeActions; do we care?
             // Copy sources with relevant files from the checkout:
             lease.path.copyRecursiveTo("src/**/*.groovy,vars/*.groovy,vars/*.txt,resources/", null, target);

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/FailingSCMSource.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/FailingSCMSource.java
@@ -1,0 +1,54 @@
+package org.jenkinsci.plugins.workflow.libs;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import hudson.AbortException;
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.scm.ChangeLogParser;
+import hudson.scm.SCM;
+import hudson.scm.SCMRevisionState;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHeadEvent;
+import jenkins.scm.api.SCMHeadObserver;
+import jenkins.scm.api.SCMRevision;
+import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceCriteria;
+import jenkins.scm.impl.mock.MockSCMRevision;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+import java.io.File;
+import java.io.IOException;
+
+public class FailingSCMSource extends SCMSource {
+
+    @Override
+    protected SCMRevision retrieve(@NonNull final String thingName, @NonNull final TaskListener listener) throws IOException, InterruptedException {
+        final SCMHead head = new SCMHead(thingName);
+        return new MockSCMRevision(head, "not important");
+    }
+
+    @Override
+    protected void retrieve(final SCMSourceCriteria criteria, @NonNull final SCMHeadObserver observer, final SCMHeadEvent<?> event, @NonNull final TaskListener listener) throws IOException, InterruptedException {
+        throw new AbortException("Failing 'retrieve' on purpose!");
+    }
+
+    @NonNull
+    @Override
+    public SCM build(@NonNull final SCMHead head, final SCMRevision revision) {
+        return new SCM() {
+            @Override
+            public ChangeLogParser createChangeLogParser() {
+                return null;
+            }
+
+            @Override
+            public void checkout(@Nonnull final Run<?, ?> build, @Nonnull final Launcher launcher, @Nonnull final FilePath workspace, @Nonnull final TaskListener listener, @CheckForNull final File changelogFile, @CheckForNull final SCMRevisionState baseline) throws IOException, InterruptedException {
+                throw new AbortException("Failing 'checkout' on purpose!");
+            }
+        };
+    }
+
+}


### PR DESCRIPTION
Similar to jenkinsci/workflow-cps-plugin#147, this adds a retry to the global pipeline library source control-based retrieval, allowing runs to survive temporary network outages when they are attempting to load their libraries.

Testing
=======
1. The output of the new integration test (`retry` - adapted from the test with the same name added in jenkinsci/workflow-cps-plugin#147) looks like the following:
    ```
    === Starting retry(org.jenkinsci.plugins.workflow.libs.SCMSourceRetrieverTest)
       0.077 [id=17]	INFO	o.jvnet.hudson.test.WarExploder#explode: Picking up existing exploded jenkins.war at C:\Users\odagenais\oss\jenkinsci\workflow-cps-global-lib-plugin\target\jenkins-for-test
       0.422 [id=17]	INFO	o.jvnet.hudson.test.JenkinsRule#createWebServer: Running on http://localhost:26702/jenkins/
       1.251 [id=24]	INFO	jenkins.InitReactorRunner$1#onAttained: Started initialization
       5.415 [id=24]	INFO	jenkins.InitReactorRunner$1#onAttained: Listed all plugins
       7.732 [id=46]	INFO	jenkins.InitReactorRunner$1#onAttained: Prepared all plugins
       7.732 [id=46]	INFO	jenkins.InitReactorRunner$1#onAttained: Started all plugins
       7.737 [id=34]	INFO	jenkins.InitReactorRunner$1#onAttained: Augmented all extensions
       8.448 [id=34]	INFO	jenkins.InitReactorRunner$1#onAttained: Loaded all jobs
       8.880 [id=39]	INFO	o.j.main.modules.sshd.SSHD#start: Started SSHD at port 26745
       8.880 [id=39]	INFO	jenkins.InitReactorRunner$1#onAttained: Completed initialization
       9.126 [id=74]	WARNING	hudson.Util#warnWindowsSymlink: Symbolic links enabled on this platform but disabled for this user; run as administrator or use Local Security Policy > Security Settings > Local Policies > User Rights Assignment > Create symbolic links
       9.157 [p #1] Started
       9.482 [p #1] Loading library retry@master
       9.483 [p #1] ERROR: Failing 'checkout' on purpose!
       9.483 [p #1] Retrying after 10 seconds
      19.463 [id=74]	INFO	o.j.p.workflow.job.WorkflowRun#finish: p #1 completed: FAILURE
      19.465 [p #1] ERROR: Failing 'checkout' on purpose!
      19.465 [p #1] ERROR: Maximum checkout retry attempts reached, aborting
      19.517 [p #1] org.codehaus.groovy.control.MultipleCompilationErrorsException: startup failed:
      19.517 [p #1] WorkflowScript: Loading libraries failed
      19.517 [p #1] 
      19.517 [p #1] 1 error
      19.518 [p #1] 
      19.518 [p #1] 	at org.codehaus.groovy.control.ErrorCollector.failIfErrors(ErrorCollector.java:310)
      19.518 [p #1] 	at org.codehaus.groovy.control.CompilationUnit.applyToPrimaryClassNodes(CompilationUnit.java:1073)
      19.518 [p #1] 	at org.codehaus.groovy.control.CompilationUnit.doPhaseOperation(CompilationUnit.java:591)
      19.518 [p #1] 	at org.codehaus.groovy.control.CompilationUnit.processPhaseOperations(CompilationUnit.java:569)
      19.518 [p #1] 	at org.codehaus.groovy.control.CompilationUnit.compile(CompilationUnit.java:546)
      19.518 [p #1] 	at groovy.lang.GroovyClassLoader.doParseClass(GroovyClassLoader.java:298)
      19.518 [p #1] 	at groovy.lang.GroovyClassLoader.parseClass(GroovyClassLoader.java:268)
      19.518 [p #1] 	at groovy.lang.GroovyShell.parseClass(GroovyShell.java:688)
      19.518 [p #1] 	at groovy.lang.GroovyShell.parse(GroovyShell.java:700)
      19.518 [p #1] 	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.doParse(CpsGroovyShell.java:129)
      19.518 [p #1] 	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.reparse(CpsGroovyShell.java:123)
      19.518 [p #1] 	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.parseScript(CpsFlowExecution.java:516)
      19.518 [p #1] 	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.start(CpsFlowExecution.java:479)
      19.518 [p #1] 	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:221)
      19.519 [p #1] 	at hudson.model.ResourceController.execute(ResourceController.java:98)
      19.519 [p #1] 	at hudson.model.Executor.run(Executor.java:410)
      19.519 [p #1] Finished: FAILURE
      19.535 [id=17]	INFO	jenkins.model.Jenkins#cleanUp: Stopping Jenkins
      19.549 [id=17]	INFO	jenkins.model.Jenkins$21#onAttained: Started termination
      19.555 [id=17]	INFO	jenkins.model.Jenkins$21#onAttained: Completed termination
      19.556 [id=17]	INFO	jenkins.model.Jenkins#_cleanUpDisconnectComputers: Starting node disconnection
      19.567 [id=90]	INFO	h.TcpSlaveAgentListener$ConnectionHandler#run: Accepted connection #1 from /10.0.75.1:26773
      19.570 [id=17]	INFO	jenkins.model.Jenkins#_cleanUpShutdownPluginManager: Stopping plugin manager
      19.570 [id=17]	INFO	jenkins.model.Jenkins#_cleanUpPersistQueue: Persisting build queue
      19.581 [id=17]	INFO	jenkins.model.Jenkins#_cleanUpAwaitDisconnects: Waiting for node disconnection completion
      19.581 [id=17]	INFO	jenkins.model.Jenkins#cleanUp: Jenkins stopped
    WARN: The method class org.apache.commons.logging.impl.SLF4JLogFactory#release() was invoked.
    WARN: Please see http://www.slf4j.org/codes.html#release for an explanation.
    ```
    I would like to direct your attention to the `Retrying after 10 seconds` that follows the first error and then the checkout is re-attempted, as evidenced by the second instance of `ERROR: Failing 'checkout' on purpose!`.
2. `mvn test` ended with:
    ```
    [INFO] Results:
    [INFO]
    [WARNING] Tests run: 74, Failures: 0, Errors: 0, Skipped: 2
    [INFO]
    [INFO] ------------------------------------------------------------------------
    [INFO] BUILD SUCCESS
    [INFO] ------------------------------------------------------------------------
    [INFO] Total time: 10:49 min
    ```
Mission accomplished!