### PR TITLE
[JENKINS-52313] Add encoding argument to ResourceStep and support Base64 encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,8 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <jenkins.version>2.7.3</jenkins.version>
-        <java.level>7</java.level>
+        <jenkins.version>2.60.3</jenkins.version>
+        <java.level>8</java.level>
         <workflow-cps-plugin.version>2.39</workflow-cps-plugin.version>
         <git-plugin.version>3.6.4</git-plugin.version>
         <scm-api-plugin.version>2.2.5</scm-api-plugin.version>

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -47,7 +48,6 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 import org.jenkinsci.plugins.workflow.cps.GlobalVariable;
@@ -215,7 +215,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowCopier;
 
     private static String readResource(FilePath file, @CheckForNull String encoding) throws IOException, InterruptedException {
         if ("Base64".equals(encoding)) {
-            return Base64.encodeBase64String(IOUtils.toByteArray(file.read()));
+            return Base64.getEncoder().encodeToString(IOUtils.toByteArray(file.read()));
         } else {
             return IOUtils.toString(file.read(), encoding);
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
@@ -217,7 +217,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowCopier;
         if ("Base64".equals(encoding)) {
             return Base64.getEncoder().encodeToString(IOUtils.toByteArray(file.read()));
         } else {
-            return IOUtils.toString(file.read(), encoding);
+            return IOUtils.toString(file.read(), encoding); // The platform default is used if encoding is null.
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/ResourceStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/ResourceStep.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.workflow.libs;
 
 import hudson.AbortException;
 import hudson.Extension;
+import hudson.Util;
 import java.util.Map;
 import javax.inject.Inject;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
@@ -34,6 +35,7 @@ import org.jenkinsci.plugins.workflow.steps.AbstractStepDescriptorImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractStepImpl;
 import org.jenkinsci.plugins.workflow.steps.AbstractSynchronousStepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * Step to load a resource from a library.
@@ -41,6 +43,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class ResourceStep extends AbstractStepImpl {
 
     private final String resource;
+    private String encoding;
 
     @DataBoundConstructor public ResourceStep(String resource) {
         this.resource = resource;
@@ -48,6 +51,14 @@ public class ResourceStep extends AbstractStepImpl {
 
     public String getResource() {
         return resource;
+    }
+
+    public String getEncoding() {
+        return encoding;
+    }
+
+    @DataBoundSetter public void setEncoding(String encoding) {
+        this.encoding = Util.fixEmptyAndTrim(encoding);
     }
 
     @Extension public static class DescriptorImpl extends AbstractStepDescriptorImpl {
@@ -74,7 +85,7 @@ public class ResourceStep extends AbstractStepImpl {
 
         @Override protected String run() throws Exception {
             String resource = step.resource;
-            Map<String,String> contents = LibraryAdder.findResources((CpsFlowExecution) getContext().get(FlowExecution.class), resource);
+            Map<String,String> contents = LibraryAdder.findResources((CpsFlowExecution) getContext().get(FlowExecution.class), resource, step.encoding);
             if (contents.isEmpty()) {
                 throw new AbortException(Messages.ResourceStep_no_such_library_resource_could_be_found_(resource));
             } else if (contents.size() == 1) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/ResourceStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/ResourceStep.java
@@ -28,6 +28,7 @@ import hudson.AbortException;
 import hudson.Extension;
 import hudson.Util;
 import java.util.Map;
+import javax.annotation.CheckForNull;
 import javax.inject.Inject;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 import org.jenkinsci.plugins.workflow.flow.FlowExecution;
@@ -53,10 +54,15 @@ public class ResourceStep extends AbstractStepImpl {
         return resource;
     }
 
-    public String getEncoding() {
+    public @CheckForNull String getEncoding() {
         return encoding;
     }
 
+    /**
+     * Set the encoding to be used when loading the resource. If the specified value is null or
+     * whitespace-only, then the platform default encoding will be used. Binary resources can be
+     * loaded as a Base64-encoded string by specifying {@code Base64} as the encoding.
+     */
     @DataBoundSetter public void setEncoding(String encoding) {
         this.encoding = Util.fixEmptyAndTrim(encoding);
     }

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/ResourceStep/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/ResourceStep/config.jelly
@@ -28,4 +28,7 @@ THE SOFTWARE.
     <f:entry field="resource" title="Resource path">
         <f:textbox/>
     </f:entry>
+    <f:entry field="encoding" title="${%Character encoding}">
+        <f:textbox/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/ResourceStep/help-encoding.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/ResourceStep/help-encoding.html
@@ -1,0 +1,5 @@
+<div>
+    The encoding to use when reading the resource.
+    If left blank, the platform default encoding will be used.
+    Binary files can be read into a Base64-encoded string by specifying &quot;Base64&quot; as the encoding.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/ResourceStep/help-resource.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/ResourceStep/help-resource.html
@@ -1,0 +1,3 @@
+<div>
+    Relative (<code>/</code>-separated) path to a resource in a shared library's <code>/resources</code> folder.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/ResourceStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/ResourceStep/help.html
@@ -1,0 +1,3 @@
+<div>
+    Reads a resource from a shared library and returns its content as a plain string.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/ResourceStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/ResourceStepTest.java
@@ -25,16 +25,23 @@
 package org.jenkinsci.plugins.workflow.libs;
 
 import hudson.model.Result;
+import hudson.model.Run;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
+import org.apache.commons.codec.binary.Base64;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.junit.Test;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
 public class ResourceStepTest {
@@ -79,6 +86,29 @@ public class ResourceStepTest {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("@Library(['stuff1', 'stuff2']) import pkg.Stuff; echo(/got ${Stuff.contents(this)}/)", true));
         r.assertLogContains(Messages.ResourceStep_library_resource_ambiguous_among_librari("pkg/file", "[stuff1, stuff2]"), r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0)));
+    }
+
+    @Issue("JENKINS-52313")
+    @Test public void specifyResourceEncoding() throws Exception {
+        sampleRepo.init();
+        sampleRepo.write("src/pkg/Stuff.groovy", "package pkg; class Stuff {" +
+                "static def utf8(script) {script.libraryResource(resource: 'pkg/utf8', encoding: 'ISO-8859-15')}\n" +
+                "static def binary(script) {script.libraryResource(resource: 'pkg/binary', encoding: 'Base64')}}");
+        Path resourcesDir = Paths.get(sampleRepo.getRoot().getPath(), "resources", "pkg");
+        Files.createDirectories(resourcesDir);
+        // '¤' encoded using ISO-8859-1 should turn into '€' when decoding using ISO-8859-15.
+        Files.write(resourcesDir.resolve("utf8"), Arrays.asList("¤"), StandardCharsets.ISO_8859_1);
+        byte[] binaryData = {0x48, 0x45, 0x4c, 0x4c, 0x4f, (byte) 0x80, (byte) 0xec, (byte) 0xf4, 0x00, 0x0d, 0x1b};
+        Files.write(resourcesDir.resolve("binary"), binaryData);
+        sampleRepo.git("add", "src", "resources");
+        sampleRepo.git("commit", "--message=init");
+        GlobalLibraries.get().setLibraries(Collections.singletonList(
+            new LibraryConfiguration("stuff", new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)))));
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("@Library('stuff@master') import pkg.Stuff; echo(Stuff.utf8(this)); echo(Stuff.binary(this))", true));
+        Run run = r.buildAndAssertSuccess(p);
+        r.assertLogContains("€", run);
+        r.assertLogContains(Base64.encodeBase64String(binaryData), run);
     }
 
 }


### PR DESCRIPTION
See [JENKINS-52313](https://issues.jenkins-ci.org/browse/JENKINS-52313).

Adds support for a special encoding named "Base64" that can be used for binary files. Useful in tandem with jenkinsci/workflow-basic-steps-plugin#66 to copy binary resource files from shared libraries to the workspace.

~I'd prefer to use Java 8's Base64 API but the plugin is currently building against Java 7 so I am using commons-compress via Jenkins core.~ Baseline has been updated to Java 8 and Jenkins 2.60.3 to use the new Base64 API.

@reviewbybees @jennbriden