### PR TITLE
[JENKINS-53485] fix to a file leak introduced in libraryResource

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
@@ -33,6 +33,7 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -214,10 +215,12 @@ import org.jenkinsci.plugins.workflow.flow.FlowCopier;
     }
 
     private static String readResource(FilePath file, @CheckForNull String encoding) throws IOException, InterruptedException {
-        if ("Base64".equals(encoding)) {
-            return Base64.getEncoder().encodeToString(IOUtils.toByteArray(file.read()));
-        } else {
-            return IOUtils.toString(file.read(), encoding); // The platform default is used if encoding is null.
+        try (InputStream in = file.read()) {
+            if ("Base64".equals(encoding)) {
+                return Base64.getEncoder().encodeToString(IOUtils.toByteArray(in));
+            } else {
+                return IOUtils.toString(in, encoding); // The platform default is used if encoding is null.
+            }
         }
     }
 


### PR DESCRIPTION
See [JENKINS-53485](https://issues.jenkins-ci.org/browse/JENKINS-53485). 

This wraps access to the InputStream of a file with a try-with-resources block. Prior to recent changes, access to the file contents was done with readToString which does the same.

This change was causing a pretty severe file leak, and this update will wrap the resource in a try-with-resources block like the original implementation to prevent the leak.