### PR TITLE
[JENKINS-40109] Pre-evaluate compilation errors to make them serializable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/global/CompilationErrorException.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/global/CompilationErrorException.java
@@ -12,7 +12,14 @@ import java.io.NotSerializableException;
  */
 public class CompilationErrorException extends RuntimeException {
     public CompilationErrorException(MultipleCompilationErrorsException original) {
-        super(original.toString());
+        super(original.getMessage());
         setStackTrace(original.getStackTrace());
     }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
+
+    public static final long serialVersionUID = 1;
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/global/CompilationErrorException.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/global/CompilationErrorException.java
@@ -1,0 +1,18 @@
+package org.jenkinsci.plugins.workflow.cps.global;
+
+import org.codehaus.groovy.control.MultipleCompilationErrorsException;
+
+import java.io.NotSerializableException;
+
+/**
+ * An exception that replaces Groovy's {@link MultipleCompilationErrorsException},
+ * because that is not serializable (which would, under certain circumstances,
+ * lead to the user being presented with a {@link NotSerializableException} instead
+ * of a compilation error -- see JENKINS-40109).
+ */
+public class CompilationErrorException extends RuntimeException {
+    public CompilationErrorException(MultipleCompilationErrorsException original) {
+        super(original.toString());
+        setStackTrace(original.getStackTrace());
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/global/UserDefinedGlobalVariable.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/global/UserDefinedGlobalVariable.java
@@ -54,7 +54,7 @@ public class UserDefinedGlobalVariable extends GlobalVariable {
 
             try {
                 instance = c.getExecution().getShell().getClassLoader().loadClass(getName()).newInstance();
-            } catch(MultipleCompilationErrorsException ex) {
+            } catch(MultipleCompilationErrorsException ex) { //JENKINS-40109
                 throw new CompilationErrorException(ex);
             }
             /* We could also skip registration of vars in GroovyShellDecoratorImpl and use:

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/global/UserDefinedGlobalVariable.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/global/UserDefinedGlobalVariable.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.workflow.cps.global;
 import groovy.lang.Binding;
 import org.apache.commons.io.Charsets;
 import org.apache.commons.io.FileUtils;
+import org.codehaus.groovy.control.MultipleCompilationErrorsException;
 import org.jenkinsci.plugins.workflow.cps.CpsScript;
 import org.jenkinsci.plugins.workflow.cps.CpsThread;
 import org.jenkinsci.plugins.workflow.cps.GlobalVariable;
@@ -51,7 +52,11 @@ public class UserDefinedGlobalVariable extends GlobalVariable {
             if (c==null)
                 throw new IllegalStateException("Expected to be called from CpsThread");
 
-            instance = c.getExecution().getShell().getClassLoader().loadClass(getName()).newInstance();
+            try {
+                instance = c.getExecution().getShell().getClassLoader().loadClass(getName()).newInstance();
+            } catch(MultipleCompilationErrorsException ex) {
+                throw new CompilationErrorException(ex);
+            }
             /* We could also skip registration of vars in GroovyShellDecoratorImpl and use:
                  instance = c.getExecution().getShell().parse(source(".groovy"));
                But then the source will appear in CpsFlowExecution.loadedScripts and be offered up for ReplayAction.

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/global/CompilationErrorExceptionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/global/CompilationErrorExceptionTest.java
@@ -1,0 +1,42 @@
+package org.jenkinsci.plugins.workflow.cps.global;
+
+import com.cloudbees.hudson.plugins.folder.Folder;
+import hudson.model.Run;
+import hudson.plugins.git.GitSCM;
+import jenkins.plugins.git.GitSCMSource;
+import jenkins.plugins.git.GitSampleRepoRule;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.libs.GlobalLibraries;
+import org.jenkinsci.plugins.workflow.libs.LibraryConfiguration;
+import org.jenkinsci.plugins.workflow.libs.SCMRetriever;
+import org.jenkinsci.plugins.workflow.libs.SCMSourceRetriever;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Collections;
+
+@Issue("JENKINS-40109")
+public class CompilationErrorExceptionTest extends Assert {
+    @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
+    @Rule public JenkinsRule r = new JenkinsRule();
+    @Rule public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
+
+    @Test public void catchSyntaxError() throws Exception {
+        sampleRepo.init();
+        sampleRepo.write("vars/mymagic.groovy", "def call() { echo([a:'alpha' b:'beta']) } //syntax error: missing comma");
+        sampleRepo.git("add", "vars");
+        sampleRepo.git("commit", "--message=init");
+        GlobalLibraries.get().setLibraries(Collections.singletonList(new LibraryConfiguration("badlib", new SCMSourceRetriever(new GitSCMSource(sampleRepo.toString())))));
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("@Library('badlib@master') _; try { mymagic(); echo 'why are we here?' } catch(err) { echo 'forcing CPS serialization...'; sleep 1; echo 'did we die?' }", true));
+        Run run =  r.buildAndAssertSuccess(p);
+        r.assertLogNotContains("why are we here?", run);
+        r.assertLogContains("did we die?", run);
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/global/CompilationErrorExceptionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/global/CompilationErrorExceptionTest.java
@@ -34,9 +34,10 @@ public class CompilationErrorExceptionTest extends Assert {
         sampleRepo.git("commit", "--message=init");
         GlobalLibraries.get().setLibraries(Collections.singletonList(new LibraryConfiguration("badlib", new SCMSourceRetriever(new GitSCMSource(sampleRepo.toString())))));
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
-        p.setDefinition(new CpsFlowDefinition("@Library('badlib@master') _; try { mymagic(); echo 'why are we here?' } catch(err) { echo 'forcing CPS serialization...'; sleep 1; echo 'did we die?' }", true));
+        p.setDefinition(new CpsFlowDefinition("@Library('badlib@master') _; try { mymagic(); echo 'why are we here?' } catch(err) { echo err.getMessage(); echo 'forcing CPS serialization...'; sleep 1; echo 'did we die?' }", true));
         Run run =  r.buildAndAssertSuccess(p);
         r.assertLogNotContains("why are we here?", run);
+        r.assertLogContains("unexpected token", run); //syntax error message
         r.assertLogContains("did we die?", run);
     }
 }


### PR DESCRIPTION
One way to solve [JENKINS-40109](https://issues.jenkins-ci.org/browse/JENKINS-40109).

I have one small uncertainty: do you think anyone could be relying on the details inside the MultipleCompilationErrorsException? Should we save it as a transient field inside CompilationErrorException (and override getCause() to return it)?