### PR TITLE
[JENKINS-48516] Uniquify distinct groups of radio buttons

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/config.jelly
@@ -40,5 +40,5 @@ THE SOFTWARE.
     <f:entry field="includeInChangesets" title="${%Include @Library changes in job recent changes}">
         <f:checkbox default="true"/>
     </f:entry>
-    <f:descriptorRadioList varName="retriever" instance="${instance.retriever}" descriptors="${descriptor.retrieverDescriptors}" title="${%Retrieval method}"/>
+    <f:descriptorRadioList varName="${h.generateId()}.retriever" instance="${instance.retriever}" descriptors="${descriptor.retrieverDescriptors}" title="${%Retrieval method}"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/config.jelly
@@ -40,5 +40,6 @@ THE SOFTWARE.
     <f:entry field="includeInChangesets" title="${%Include @Library changes in job recent changes}">
         <f:checkbox default="true"/>
     </f:entry>
+    <!-- TODO: Remove ${h.generateId()}. once core baseline includes https://github.com/jenkinsci/jenkins/pull/3672 -->
     <f:descriptorRadioList varName="${h.generateId()}.retriever" instance="${instance.retriever}" descriptors="${descriptor.retrieverDescriptors}" title="${%Retrieval method}"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMRetriever/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMRetriever/config.jelly
@@ -25,5 +25,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:descriptorRadioList varName="scm" instance="${instance.scm}" descriptors="${descriptor.SCMDescriptors}" title="${%Source Code Management}"/>
+    <f:descriptorRadioList varName="${h.generateId()}.scm" instance="${instance.scm}" descriptors="${descriptor.SCMDescriptors}" title="${%Source Code Management}"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMRetriever/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMRetriever/config.jelly
@@ -25,5 +25,6 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <!-- TODO: Remove ${h.generateId()}. once core baseline includes https://github.com/jenkinsci/jenkins/pull/3672 -->
     <f:descriptorRadioList varName="${h.generateId()}.scm" instance="${instance.scm}" descriptors="${descriptor.SCMDescriptors}" title="${%Source Code Management}"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever/config.jelly
@@ -25,5 +25,5 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:descriptorRadioList varName="scm" instance="${instance.scm}" descriptors="${descriptor.SCMDescriptors}" title="${%Source Code Management}"/>
+    <f:descriptorRadioList varName="${h.generateId()}.scm" instance="${instance.scm}" descriptors="${descriptor.SCMDescriptors}" title="${%Source Code Management}"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever/config.jelly
@@ -25,5 +25,6 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <!-- TODO: Remove ${h.generateId()}. once core baseline includes https://github.com/jenkinsci/jenkins/pull/3672 -->
     <f:descriptorRadioList varName="${h.generateId()}.scm" instance="${instance.scm}" descriptors="${descriptor.SCMDescriptors}" title="${%Source Code Management}"/>
 </j:jelly>


### PR DESCRIPTION
See [JENKINS-48516](https://issues.jenkins-ci.org/browse/JENKINS-48516).

Right now, if you have multiple shared libraries defined, when you load the configuration page, only the last library's SCM settings will be visible. 

The reason for this seems to be that the names of radio button groups are not distinct for each library. [repeatable.js](https://github.com/jenkinsci/jenkins/blob/22aa2e6e766074d11249893e3f35e0b99e20d3d0/core/src/main/resources/lib/form/repeatable/repeatable.js#L189) tries to add a prefix to uniquify radio buttons in distinct `repeatable-chunk`s, but here we have ambiguity even within a single `repeatable-chunk`, and I'm not sure if the `repeatable.js` code works correctly when loading existing data vs adding new radio buttons to a live page dynamically using `repeatable:add` buttons (Based on [the generated HTML](https://gist.github.com/dwnusbaum/746e0a7a4d2cab9e6f28733178c51f47) I'd think that there should be no issue, so it seems like the JS-based uniquifying might happen too late to fix dupes during the initial page load).

I'd like to upstream this fix into core (EDIT: jenkinsci/jenkins#3672) for all `f:descriptorRadioList`s, since I don't think it would ever hurt, but I am opening this PR independently since I assume we won't want to bump our core dependency to the bleeding edge for a fix like this.

@reviewbybees 