### PR TITLE
Clarify that you can control if Pipeline shared library changes should…

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/config.jelly
@@ -37,7 +37,7 @@ THE SOFTWARE.
     <f:entry field="allowVersionOverride" title="${%Allow default version to be overridden}">
         <f:checkbox default="true"/>
     </f:entry>
-    <f:entry field="includeInChangesets" title="${%Include @Library changes in job recent changes, and changes to this library should trigger jobs that use it}">
+    <f:entry field="includeInChangesets" title="${%Include @Library changes in job recent changes}">
         <f:checkbox default="true"/>
     </f:entry>
     <f:descriptorRadioList varName="retriever" instance="${instance.retriever}" descriptors="${descriptor.retrieverDescriptors}" title="${%Retrieval method}"/>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/config.jelly
@@ -37,7 +37,7 @@ THE SOFTWARE.
     <f:entry field="allowVersionOverride" title="${%Allow default version to be overridden}">
         <f:checkbox default="true"/>
     </f:entry>
-    <f:entry field="includeInChangesets" title="${%Include @Library changes in job recent changes}">
+    <f:entry field="includeInChangesets" title="${%Include @Library changes in job recent changes, and changes to this library should trigger jobs that use it}">
         <f:checkbox default="true"/>
     </f:entry>
     <f:descriptorRadioList varName="retriever" instance="${instance.retriever}" descriptors="${descriptor.retrieverDescriptors}" title="${%Retrieval method}"/>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/help-includeInChangesets.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/help-includeInChangesets.html
@@ -1,4 +1,4 @@
 <div>
-  <p>If checked, any changes in the library will be included in the changesets of a build.
+  <p>If checked, any changes in the library will be included in the changesets of a build, and changing the library would cause new builds to run for Pipelines that include this library.
   <p>This can be overridden in the jenkinsfile: @Library(value="name@version", changelog=true|false)
 </div>


### PR DESCRIPTION
… trigger new builds for consuming jobs

It's not currently obvious in the Jenkins UI that the `Include @Library changes in job recent changes` option not only will control if the Pipelines will list the library changes in their change log, but it also controls whether a new build would be triggered whenever the Pipeline shared library is updated for any job that includes the library.

I'm proposing updating the description of the checkbox as well as the help text to make this more clear.