### PR TITLE
[JENKINS-43802] No context available for credentials from SCMSource.retrieve(String, TaskListener)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <java.level>8</java.level>
         <workflow-cps-plugin.version>2.67</workflow-cps-plugin.version>
         <git-plugin.version>3.6.4</git-plugin.version>
-        <scm-api-plugin.version>2.5.0-SNAPSHOT</scm-api-plugin.version> <!-- TODO https://github.com/jenkinsci/scm-api-plugin/pull/65 -->
+        <scm-api-plugin.version>2.5.0-rc464.915933672136</scm-api-plugin.version> <!-- TODO https://github.com/jenkinsci/scm-api-plugin/pull/65 -->
         <workflow-scm-step-plugin.version>2.4</workflow-scm-step-plugin.version>
         <workflow-multibranch-plugin.version>2.10</workflow-multibranch-plugin.version>
         <workflow-step-api-plugin.version>2.19</workflow-step-api-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <useBeta>true</useBeta>
         <workflow-cps-plugin.version>2.71</workflow-cps-plugin.version>
         <git-plugin.version>4.0.0-rc</git-plugin.version>
-        <scm-api-plugin.version>2.6.2</scm-api-plugin.version>
+        <scm-api-plugin.version>2.6.3</scm-api-plugin.version>
         <workflow-scm-step-plugin.version>2.7</workflow-scm-step-plugin.version>
         <workflow-multibranch-plugin.version>2.21</workflow-multibranch-plugin.version>
         <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <java.level>8</java.level>
         <workflow-cps-plugin.version>2.67</workflow-cps-plugin.version>
         <git-plugin.version>3.6.4</git-plugin.version>
-        <scm-api-plugin.version>2.2.7</scm-api-plugin.version>
+        <scm-api-plugin.version>2.5.0-SNAPSHOT</scm-api-plugin.version> <!-- TODO https://github.com/jenkinsci/scm-api-plugin/pull/65 -->
         <workflow-scm-step-plugin.version>2.4</workflow-scm-step-plugin.version>
         <workflow-multibranch-plugin.version>2.10</workflow-multibranch-plugin.version>
         <workflow-step-api-plugin.version>2.19</workflow-step-api-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
         <java.level>8</java.level>
         <workflow-cps-plugin.version>2.67</workflow-cps-plugin.version>
         <git-plugin.version>3.6.4</git-plugin.version>
-        <scm-api-plugin.version>2.5.0-rc464.915933672136</scm-api-plugin.version> <!-- TODO https://github.com/jenkinsci/scm-api-plugin/pull/65 -->
+        <scm-api-plugin.version>2.6.2</scm-api-plugin.version>
         <workflow-scm-step-plugin.version>2.4</workflow-scm-step-plugin.version>
         <workflow-multibranch-plugin.version>2.10</workflow-multibranch-plugin.version>
         <workflow-step-api-plugin.version>2.19</workflow-step-api-plugin.version>

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration.java
@@ -39,6 +39,7 @@ import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
+import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
@@ -159,7 +160,7 @@ public class LibraryConfiguration extends AbstractDescribableImpl<LibraryConfigu
             return FormValidation.ok();
         }
 
-        public FormValidation doCheckDefaultVersion(@QueryParameter String defaultVersion, @QueryParameter boolean implicit, @QueryParameter boolean allowVersionOverride, @QueryParameter String name) {
+        public FormValidation doCheckDefaultVersion(@AncestorInPath Item context, @QueryParameter String defaultVersion, @QueryParameter boolean implicit, @QueryParameter boolean allowVersionOverride, @QueryParameter String name) {
             if (defaultVersion.isEmpty()) {
                 if (implicit) {
                     return FormValidation.error("If you load a library implicitly, you must specify a default version.");
@@ -172,7 +173,7 @@ public class LibraryConfiguration extends AbstractDescribableImpl<LibraryConfigu
                 for (LibraryResolver resolver : ExtensionList.lookup(LibraryResolver.class)) {
                     for (LibraryConfiguration config : resolver.fromConfiguration(Stapler.getCurrentRequest())) {
                         if (config.getName().equals(name)) {
-                            return config.getRetriever().validateVersion(name, defaultVersion);
+                            return config.getRetriever().validateVersion(name, defaultVersion, context);
                         }
                     }
                 }
@@ -181,14 +182,14 @@ public class LibraryConfiguration extends AbstractDescribableImpl<LibraryConfigu
         }
 
         /* TODO currently impossible; autoCompleteField does not support passing neighboring fields:
-        public AutoCompletionCandidates doAutoCompleteDefaultVersion(@QueryParameter String defaultVersion, @QueryParameter String name) {
+        public AutoCompletionCandidates doAutoCompleteDefaultVersion(@AncestorInPath Item context, @QueryParameter String defaultVersion, @QueryParameter String name) {
             AutoCompletionCandidates candidates = new AutoCompletionCandidates();
             for (LibraryResolver resolver : ExtensionList.lookup(LibraryResolver.class)) {
                 for LibraryConfiguration config : resolver.fromConfiguration(Stapler.getCurrentRequest()) {
                     // TODO define LibraryRetriever.completeVersions
                     if (config.getName().equals(name) && config.getRetriever() instanceof SCMSourceRetriever) {
                         try {
-                            for (String revision : ((SCMSourceRetriever) config.getRetriever()).getScm().fetchRevisions(null)) {
+                            for (String revision : ((SCMSourceRetriever) config.getRetriever()).getScm().fetchRevisions(null, context)) {
                                 if (revision.startsWith(defaultVersion)) {
                                     candidates.add(revision);
                                 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRetriever.java
@@ -27,10 +27,13 @@ package org.jenkinsci.plugins.workflow.libs;
 import hudson.AbortException;
 import hudson.ExtensionPoint;
 import hudson.FilePath;
+import hudson.Util;
 import hudson.model.AbstractDescribableImpl;
+import hudson.model.Item;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.util.FormValidation;
+import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 /**
@@ -59,16 +62,26 @@ public abstract class LibraryRetriever extends AbstractDescribableImpl<LibraryRe
      * @param listener a way to report progress
      * @throws Exception if there is any problem (use {@link AbortException} for user errors)
      */
+    // TODO this should have been made nonabstract and deprecated and delegated to the new version
     public abstract void retrieve(@Nonnull String name, @Nonnull String version, @Nonnull FilePath target, @Nonnull Run<?,?> run, @Nonnull TaskListener listener) throws Exception;
+
+    @Deprecated
+    public FormValidation validateVersion(@Nonnull String name, @Nonnull String version) {
+        if (Util.isOverridden(LibraryRetriever.class, getClass(), "validateVersion", String.class, String.class, Item.class)) {
+            return validateVersion(name, version, null);
+        }
+        return FormValidation.ok();
+    }
 
     /**
      * Offer to validate a proposed {@code version} for {@link #retrieve}.
      * @param name the proposed library name
      * @param version a proposed version
+     * @param context optional context in which this runs
      * @return by default, OK
      */
-    public FormValidation validateVersion(@Nonnull String name, @Nonnull String version) {
-        return FormValidation.ok();
+    public FormValidation validateVersion(@Nonnull String name, @Nonnull String version, @CheckForNull Item context) {
+        return validateVersion(name, version);
     }
 
     @Override public LibraryRetrieverDescriptor getDescriptor() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRetriever.java
@@ -62,7 +62,7 @@ public abstract class LibraryRetriever extends AbstractDescribableImpl<LibraryRe
      * @param listener a way to report progress
      * @throws Exception if there is any problem (use {@link AbortException} for user errors)
      */
-    // TODO this should have been made nonabstract and deprecated and delegated to the new version
+    // TODO this should have been made nonabstract and deprecated and delegated to the new version; may be able to use access-modifier to help
     public abstract void retrieve(@Nonnull String name, @Nonnull String version, @Nonnull FilePath target, @Nonnull Run<?,?> run, @Nonnull TaskListener listener) throws Exception;
 
     @Deprecated

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMRetriever.java
@@ -29,6 +29,7 @@ import hudson.FilePath;
 import hudson.Util;
 import hudson.model.Descriptor;
 import hudson.model.DescriptorVisibilityFilter;
+import hudson.model.Item;
 import hudson.model.Items;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -67,7 +68,8 @@ public class SCMRetriever extends LibraryRetriever {
     @Override public void retrieve(String name, String version, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
         SCMSourceRetriever.doRetrieve(name, true, scm, target, run, listener);
     }
-    @Override public FormValidation validateVersion(String name, String version) {
+    
+    @Override public FormValidation validateVersion(String name, String version, Item context) {
         if (!Items.XSTREAM2.toXML(scm).contains("${library." + name + ".version}")) {
             return FormValidation.warningWithMarkup("When using <b>" + getDescriptor().getDisplayName() + "</b>, you will need to include <code>${library." + Util.escape(name) + ".version}</code> in the SCM configuration somewhere.");
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
@@ -34,6 +34,7 @@ import hudson.Util;
 import hudson.model.Computer;
 import hudson.model.Descriptor;
 import hudson.model.DescriptorVisibilityFilter;
+import hudson.model.Item;
 import hudson.model.Node;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -81,7 +82,7 @@ public class SCMSourceRetriever extends LibraryRetriever {
     }
 
     @Override public void retrieve(String name, String version, boolean changelog, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
-        SCMRevision revision = retrySCMOperation(listener, () -> scm.fetch(version, listener));
+        SCMRevision revision = retrySCMOperation(listener, () -> scm.fetch(version, listener, run.getParent()));
         if (revision == null) {
             throw new AbortException("No version " + version + " found for library " + name);
         }
@@ -160,11 +161,11 @@ public class SCMSourceRetriever extends LibraryRetriever {
         return System.getProperty(WorkspaceList.class.getName(), "@");
     }
 
-    @Override public FormValidation validateVersion(String name, String version) {
+    @Override public FormValidation validateVersion(String name, String version, Item context) {
         StringWriter w = new StringWriter();
         try {
             StreamTaskListener listener = new StreamTaskListener(w);
-            SCMRevision revision = scm.fetch(version, listener);
+            SCMRevision revision = scm.fetch(version, listener, context);
             if (revision != null) {
                 // TODO validate repository structure using SCMFileSystem when implemented (JENKINS-33273)
                 return FormValidation.ok("Currently maps to revision: " + revision);

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
@@ -186,13 +186,13 @@ public class SCMSourceRetriever extends LibraryRetriever {
         }
 
         /**
-         * Returns only implementations overriding {@link SCMSource#retrieve(String, TaskListener)}.
+         * Returns only implementations overriding {@link SCMSource#retrieve(String, TaskListener)} or {@link SCMSource#retrieve(String, TaskListener, Item)}.
          */
         @Restricted(NoExternalUse.class) // Jelly, Hider
         public Collection<SCMSourceDescriptor> getSCMDescriptors() {
             List<SCMSourceDescriptor> descriptors = new ArrayList<>();
             for (SCMSourceDescriptor d : ExtensionList.lookup(SCMSourceDescriptor.class)) {
-                if (Util.isOverridden(SCMSource.class, d.clazz, "retrieve", String.class, TaskListener.class)) {
+                if (Util.isOverridden(SCMSource.class, d.clazz, "retrieve", String.class, TaskListener.class) || Util.isOverridden(SCMSource.class, d.clazz, "retrieve", String.class, TaskListener.class, Item.class)) {
                     descriptors.add(d);
                 }
             }

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetrieverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetrieverTest.java
@@ -24,27 +24,39 @@
 
 package org.jenkinsci.plugins.workflow.libs;
 
+import hudson.AbortException;
 import hudson.FilePath;
 import hudson.model.Result;
+import hudson.model.TaskListener;
+import hudson.scm.ChangeLogSet;
+import hudson.scm.SCM;
 import hudson.slaves.WorkspaceList;
-
-import java.util.List;
-import java.util.Iterator;
+import java.io.IOException;
 import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
+import jenkins.scm.api.SCMHead;
+import jenkins.scm.api.SCMHeadEvent;
+import jenkins.scm.api.SCMHeadObserver;
+import jenkins.scm.api.SCMRevision;
 import jenkins.scm.api.SCMSource;
+import jenkins.scm.api.SCMSourceCriteria;
+import jenkins.scm.api.SCMSourceDescriptor;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import hudson.scm.ChangeLogSet;
-import org.junit.ClassRule;
-import org.junit.Test;
 import static org.junit.Assert.*;
+import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
+import org.junit.Test;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.SingleFileSCM;
+import org.jvnet.hudson.test.TestExtension;
 
 public class SCMSourceRetrieverTest {
 
@@ -131,6 +143,52 @@ public class SCMSourceRetrieverTest {
             assertEquals(0, changeSets.size());
             r.assertLogNotContains("Retrying after 10 seconds", b);
         }
+    }
+
+    @Ignore("TODO does not yet work")
+    @Issue("JENKINS-43802")
+    @Test public void owner() throws Exception {
+        GlobalLibraries.get().setLibraries(Collections.singletonList(
+            new LibraryConfiguration("test", new SCMSourceRetriever(new NeedsOwnerSCMSource()))));
+        WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("@Library('test@abc123') import libVersion; echo(/loaded lib #${dlibVersion()}/)", true));
+        WorkflowRun b = r.buildAndAssertSuccess(p);
+        r.assertLogContains("loaded lib #abc123", b);
+        r.assertLogContains("Running in retrieve from p", b);
+    }
+    public static final class NeedsOwnerSCMSource extends SCMSource {
+        @Override protected SCMRevision retrieve(String version, TaskListener listener) throws IOException, InterruptedException {
+            if (getOwner() == null) {
+                throw new AbortException("No owner in retrieve!");
+            } else {
+                listener.getLogger().println("Running in retrieve from " + getOwner().getFullName());
+            }
+            return new DummySCMRevision(version, new SCMHead("trunk"));
+        }
+        @Override public SCM build(SCMHead head, SCMRevision revision) {
+            if (getOwner() == null) {
+                throw new IllegalStateException("No owner in build!");
+            }
+             String version = ((DummySCMRevision) revision).version;
+            return new SingleFileSCM("vars/libVersion.groovy", ("def call() {'" + version + "'}").getBytes());
+        }
+        private static final class DummySCMRevision extends SCMRevision {
+            private final String version;
+            DummySCMRevision(String version, SCMHead head) {
+                super(head);
+                this.version = version;
+            }
+            @Override public boolean equals(Object obj) {
+                return obj instanceof DummySCMRevision && version.equals(((DummySCMRevision) obj).version);
+            }
+            @Override public int hashCode() {
+                return version.hashCode();
+            }
+        }
+        @Override protected void retrieve(SCMSourceCriteria criteria, SCMHeadObserver observer, SCMHeadEvent<?> event, TaskListener listener) throws IOException, InterruptedException {
+            throw new IOException("not implemented");
+        }
+        @TestExtension("owner") public static final class DescriptorImpl extends SCMSourceDescriptor {}
     }
 
     @Test public void retry() throws Exception {


### PR DESCRIPTION
[JENKINS-43802](https://issues.jenkins-ci.org/browse/JENKINS-43802)

Downstream of https://github.com/jenkinsci/scm-api-plugin/pull/65.