### PR TITLE
[JENKINS-56682] Reproduce and fix issue using types from shared libraries in Script initializers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <jenkins.version>2.138.4</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
-        <workflow-cps-plugin.version>2.71-rc2340.ea3a8e1ac84d</workflow-cps-plugin.version>
+        <workflow-cps-plugin.version>2.71</workflow-cps-plugin.version>
         <git-plugin.version>4.0.0-rc</git-plugin.version>
         <scm-api-plugin.version>2.4.0</scm-api-plugin.version>
         <workflow-scm-step-plugin.version>2.7</workflow-scm-step-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,12 +66,12 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.121.3</jenkins.version>
         <java.level>8</java.level>
-        <workflow-cps-plugin.version>2.69</workflow-cps-plugin.version>
+        <workflow-cps-plugin.version>2.71-rc2336.411e4768703e</workflow-cps-plugin.version>
         <git-plugin.version>3.9.3</git-plugin.version>
         <scm-api-plugin.version>2.4.0</scm-api-plugin.version>
         <workflow-scm-step-plugin.version>2.7</workflow-scm-step-plugin.version>
         <workflow-multibranch-plugin.version>2.21</workflow-multibranch-plugin.version>
-        <workflow-step-api-plugin.version>2.19</workflow-step-api-plugin.version>
+        <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>
         <workflow-support-plugin.version>3.3</workflow-support-plugin.version>
     </properties>
     <dependencies>
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.17</version>
+            <version>1.19</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.121.3</jenkins.version>
         <java.level>8</java.level>
-        <workflow-cps-plugin.version>2.71-rc2339.fbbdab3bf56a</workflow-cps-plugin.version>
+        <workflow-cps-plugin.version>2.71-rc2340.ea3a8e1ac84d</workflow-cps-plugin.version>
         <git-plugin.version>3.9.3</git-plugin.version>
         <scm-api-plugin.version>2.4.0</scm-api-plugin.version>
         <workflow-scm-step-plugin.version>2.7</workflow-scm-step-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.121.3</jenkins.version>
         <java.level>8</java.level>
-        <workflow-cps-plugin.version>2.71-rc2336.411e4768703e</workflow-cps-plugin.version>
+        <workflow-cps-plugin.version>2.71-rc2339.fbbdab3bf56a</workflow-cps-plugin.version>
         <git-plugin.version>3.9.3</git-plugin.version>
         <scm-api-plugin.version>2.4.0</scm-api-plugin.version>
         <workflow-scm-step-plugin.version>2.7</workflow-scm-step-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.58</version>
+            <version>1.60</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -145,11 +145,6 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.7</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>apache-httpcomponents-client-4-api</artifactId>
-            <version>4.5.5-3.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -278,6 +273,15 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jenkins-ci.plugins</groupId>
+                <artifactId>apache-httpcomponents-client-4-api</artifactId>
+                <version>4.5.5-3.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -64,17 +64,22 @@
     <properties>
         <revision>2.14</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.121.1</jenkins.version>
+        <jenkins.version>2.121.3</jenkins.version>
         <java.level>8</java.level>
         <workflow-cps-plugin.version>2.69</workflow-cps-plugin.version>
-        <git-plugin.version>3.6.4</git-plugin.version>
-        <scm-api-plugin.version>2.2.7</scm-api-plugin.version>
-        <workflow-scm-step-plugin.version>2.4</workflow-scm-step-plugin.version>
-        <workflow-multibranch-plugin.version>2.10</workflow-multibranch-plugin.version>
+        <git-plugin.version>3.9.3</git-plugin.version>
+        <scm-api-plugin.version>2.4.0</scm-api-plugin.version>
+        <workflow-scm-step-plugin.version>2.7</workflow-scm-step-plugin.version>
+        <workflow-multibranch-plugin.version>2.21</workflow-multibranch-plugin.version>
         <workflow-step-api-plugin.version>2.19</workflow-step-api-plugin.version>
         <workflow-support-plugin.version>3.3</workflow-support-plugin.version>
     </properties>
     <dependencies>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-api</artifactId>
+            <version>2.33</version>
+        </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
@@ -99,7 +104,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git-client</artifactId>
-            <version>2.6.0</version> <!-- do not pick up an obsolete version from git-server -->
+            <version>2.7.6</version> <!-- do not pick up an obsolete version from git-server -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -109,7 +114,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>cloudbees-folder</artifactId>
-            <version>6.1.0</version>
+            <version>6.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -129,7 +134,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>credentials</artifactId>
-            <version>2.1.14</version>
+            <version>2.1.18</version>
         </dependency>
         <dependency>
             <groupId>org.apache.ivy</groupId>
@@ -140,6 +145,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>apache-httpcomponents-client-4-api</artifactId>
+            <version>4.5.5-3.0</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -156,19 +166,19 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.9</version>
+            <version>2.32</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.3</version>
+            <version>2.15</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.8</version>
+            <version>2.28</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -181,13 +191,6 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-multibranch</artifactId>
             <version>${workflow-multibranch-plugin.version}</version>
-            <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-scm-step</artifactId>
-            <version>${workflow-scm-step-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
@@ -271,7 +274,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>branch-api</artifactId>
-            <version>2.0.21</version>
+            <version>2.2.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
@@ -337,7 +337,7 @@ public class LibraryAdderTest {
         r.assertLogContains("set to loaded null", r.buildAndAssertSuccess(p));
     }
 
-
+    @Ignore
     @Issue("JENKINS-56682")
     @Test public void scriptFieldsWhereInitializerUsesLibrary() throws Exception {
         sampleRepo.init();
@@ -352,7 +352,7 @@ public class LibraryAdderTest {
                 "@Library('lib@master') import pkg.Foo\n" +
                 "import groovy.transform.Field\n" +
                 "@Field f = new Foo()\n" +
-                "@Field static def f = new Foo()\n", true));
+                "@Field static g = new Foo()\n", true));
         r.buildAndAssertSuccess(p);
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
@@ -337,7 +337,6 @@ public class LibraryAdderTest {
         r.assertLogContains("set to loaded null", r.buildAndAssertSuccess(p));
     }
 
-    @Ignore
     @Issue("JENKINS-56682")
     @Test public void scriptFieldsWhereInitializerUsesLibrary() throws Exception {
         sampleRepo.init();

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
@@ -337,9 +337,9 @@ public class LibraryAdderTest {
         r.assertLogContains("set to loaded null", r.buildAndAssertSuccess(p));
     }
 
-    @Ignore
+
     @Issue("JENKINS-56682")
-    @Test public void scriptVarsWhereInitializerUsesLibrary() throws Exception {
+    @Test public void scriptFieldsWhereInitializerUsesLibrary() throws Exception {
         sampleRepo.init();
         sampleRepo.write("src/pkg/Foo.groovy", "package pkg; class Foo { }");
         sampleRepo.git("add", "src");
@@ -351,7 +351,8 @@ public class LibraryAdderTest {
         p.setDefinition(new CpsFlowDefinition(
                 "@Library('lib@master') import pkg.Foo\n" +
                 "import groovy.transform.Field\n" +
-                "@Field f = new Foo()\n", true));
+                "@Field f = new Foo()\n" +
+                "@Field static def f = new Foo()\n", true));
         r.buildAndAssertSuccess(p);
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
@@ -53,7 +53,6 @@ import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import static org.junit.Assert.*;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.Rule;
 import org.jvnet.hudson.test.BuildWatcher;


### PR DESCRIPTION
Same underlying problem as [JENKINS-56682](https://issues.jenkins-ci.org/browse/JENKINS-56682). See https://github.com/jenkinsci/script-security-plugin/pull/259 and https://github.com/jenkinsci/workflow-cps-plugin/pull/297.

This PR updates a bunch of dependencies since I had already had a wip commit to do that locally. More importantly, it adds a new test whose failing stack trace looks like: 

```
org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: Scripts not permitted to use new pkg.Foo
	at org.jenkinsci.plugins.scriptsecurity.sandbox.whitelists.StaticWhitelist.rejectNew(StaticWhitelist.java:271)
	at org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxInterceptor.onNewInstance(SandboxInterceptor.java:174)
	at org.kohsuke.groovy.sandbox.impl.Checker$3.call(Checker.java:198)
	at org.kohsuke.groovy.sandbox.impl.Checker.checkedConstructor(Checker.java:203)
	at org.kohsuke.groovy.sandbox.impl.Checker$checkedConstructor.callStatic(Unknown Source)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallStatic(CallSiteArray.java:56)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callStatic(AbstractCallSite.java:194)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callStatic(AbstractCallSite.java:214)
	at WorkflowScript.<init>(WorkflowScript:3)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at org.codehaus.groovy.runtime.InvokerHelper.createScript(InvokerHelper.java:434)
Caused: groovy.lang.GroovyRuntimeException: Failed to create Script instance for class: class WorkflowScript. Reason
	at org.codehaus.groovy.runtime.InvokerHelper.createScript(InvokerHelper.java:466)
	at groovy.lang.GroovyShell.parse(GroovyShell.java:700)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.doParse(CpsGroovyShell.java:133)
	at org.jenkinsci.plugins.workflow.cps.CpsGroovyShell.reparse(CpsGroovyShell.java:126)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.parseScript(CpsFlowExecution.java:561)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.start(CpsFlowExecution.java:522)
	at org.jenkinsci.plugins.workflow.job.WorkflowRun.run(WorkflowRun.java:320)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:429)
```

EDIT: The PR now also pulls in a fix for the issue via workflow-cps and the test passes.