### PR TITLE
Make GrapeTest.var work with new versions of jenkins-test-harness

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.43</version>
+        <version>3.46</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.46</version>
+        <version>3.47</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/global/GrapeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/global/GrapeTest.java
@@ -81,12 +81,16 @@ public class GrapeTest {
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
                 FileUtils.write(new File(repo.workspace, "vars/one.groovy"),
-                    "@Grab('org.apache.commons:commons-math3:3.4.1')\n" +
-                    "import org.apache.commons.math3.complex.ComplexField\n" +
-                    "def call() {ComplexField.instance.one}");
+                    "@Grab('commons-primitives:commons-primitives:1.0')\n" +
+                    "import org.apache.commons.collections.primitives.ArrayIntList\n" +
+                    "def call() {\n" +
+                    "  def list = new ArrayIntList()\n" +
+                    "  list.incrModCount()\n" +
+                    "  list.modCount\n" +
+                    "}");
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
-                p.setDefinition(new CpsFlowDefinition("echo(/${one()} + ${one()} = ${one().add(one())}/)", true));
-                story.j.assertLogContains("(1.0, 0.0) + (1.0, 0.0) = (2.0, 0.0)", story.j.buildAndAssertSuccess(p));
+                p.setDefinition(new CpsFlowDefinition("echo(/${one()} + ${one()} = ${one() + one()}/)", true));
+                story.j.assertLogContains("1 + 1 = 2", story.j.buildAndAssertSuccess(p));
             }
         });
     }


### PR DESCRIPTION
In #65, we discovered that `GrapeTest.var` breaks with new versions of jenkins-test-harness. See https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/65#issuecomment-505091612 for details. This PR fixes the issue by switching from `commons-math3` to `commons-primitives`, which was already being used in other tests here.