### PR TITLE
Use Functions.printStackTrace

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryDecorator.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryDecorator.java
@@ -137,7 +137,7 @@ import org.jenkinsci.plugins.workflow.cps.GroovyShellDecorator;
                         if (x instanceof AbortException) {
                             listener.error(x.getMessage());
                         } else {
-                            listener.getLogger().println(Functions.printThrowable(x).trim()); // TODO 2.43+ use Functions.printStackTrace
+                            Functions.printStackTrace(x, listener.getLogger());
                         }
                         throw new CompilationFailedException(Phases.CONVERSION, source);
                     } catch (IOException x2) {


### PR DESCRIPTION
In #31, a call to `Functions.printThrowable` was added with a TODO comment to switch to `Functions.printStackTrace` when the baseline was bumped to 2.43+. The baseline is now 2.138.4, so this TODO can be completed.

This code doesn't appear to have any test coverage, but I feel confident about the change based on the similar logic that is present in `SCMSourceRetriever` and the testing I did for a similar change in jenkinsci/workflow-basic-steps-plugin#91.