### PR TITLE
[JENKINS-58771] Do not bundle JARs from apache-httpcomponents-client-4-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,8 +96,8 @@
             <artifactId>git-server</artifactId>
             <version>1.7</version>
             <exclusions>
-                 <exclusion>
-                 <!-- Workaround for packaging bug in maven-hpi-plugin, see discussion in https://github.com/jenkinsci/workflow-cps-global-lib-plugin/pull/75 -->
+                <exclusion>
+                    <!-- TODO JENKINS-58771: workaround for bug in hpi:hpi -->
                     <groupId>org.jenkins-ci.plugins</groupId>
                     <artifactId>apache-httpcomponents-client-4-api</artifactId>
                 </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -97,8 +97,8 @@
             <version>1.7</version>
             <exclusions>
                 <exclusion>
-                    <groupId>org.apache.httpcomponents</groupId>
-                    <artifactId>httpclient</artifactId>
+                    <groupId>org.jenkins-ci.plugins</groupId>
+                    <artifactId>apache-httpcomponents-client-4-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -271,12 +271,6 @@
     </dependencies>
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.jenkins-ci.plugins</groupId>
-                <artifactId>apache-httpcomponents-client-4-api</artifactId>
-                <version>4.5.5-3.0</version>
-                <scope>test</scope>
-            </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>git-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -275,6 +275,7 @@
                 <groupId>org.jenkins-ci.plugins</groupId>
                 <artifactId>apache-httpcomponents-client-4-api</artifactId>
                 <version>4.5.5-3.0</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.47</version>
+        <version>3.50</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -95,13 +95,6 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git-server</artifactId>
             <version>1.7</version>
-            <exclusions>
-                <exclusion>
-                    <!-- TODO JENKINS-58771: workaround for bug in hpi:hpi -->
-                    <groupId>org.jenkins-ci.plugins</groupId>
-                    <artifactId>apache-httpcomponents-client-4-api</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
Amends #71. Noticed via https://github.com/jenkinsci/maven-hpi-plugin/pull/130. Without this, `apache-httpcomponents-client-4-api` is in `compile` scope (despite being only here due to `workflow-basic-steps`, a `test`-scoped dep), and thus various things like `http-core` are as well, so `hpi:hpi` gets confused (since the direct dep `workflow-basic-steps` is not in its listed of recognized plugin dependencies) and bundles them, bloating the archive.