### PR TITLE
adding the ability for users to override implicitly loaded global libraries.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration.java
@@ -58,6 +58,7 @@ public class LibraryConfiguration extends AbstractDescribableImpl<LibraryConfigu
     private boolean implicit;
     private boolean allowVersionOverride = true;
     private boolean includeInChangesets = true;
+    private boolean existingLibrariesUsed = true;
 
     @DataBoundConstructor public LibraryConfiguration(String name, LibraryRetriever retriever) {
         this.name = name;
@@ -108,6 +109,17 @@ public class LibraryConfiguration extends AbstractDescribableImpl<LibraryConfigu
 
     @DataBoundSetter public void setAllowVersionOverride(boolean allowVersionOverride) {
         this.allowVersionOverride = allowVersionOverride;
+    }
+
+    /**
+     * Whether @Library references override existing global libraries.
+     */
+    public boolean isExistingLibrariesUsed() {
+        return existingLibrariesUsed;
+    }
+
+    @DataBoundSetter public void setExistingLibrariesUsed(boolean existingLibrariesUsed) {
+        this.existingLibrariesUsed = existingLibrariesUsed;
     }
 
     /**


### PR DESCRIPTION
In my company we use this shared pipeline library plugin, and I find it hard to test changes to shared pipeline libraries unless I have write access to their repository and am able to create a branch, then I can refer to the changes with @Library('libraryname@branchname').

Currently it seems there's no way to import a fork of a library to override an implicitly loaded shared library.  I'd use this functionality frequently to test any changes made in our shared libraries.

I was able to test this PR by building hpi files and importing them into the jenkinsci official docker container.  I then created a shared library here:  https://github.com/willcrain1/test-pipeline-library and forked it here as well and made minor changes:  https://github.com/jenkinspipelinetesting/test-pipeline-library

I executed the libraries in this Jenkinsfile: https://github.com/willcrain1/test-pipeline/blob/master/Jenkinsfile

@jglick @kohsuke any feedback is appreciated.