### PR TITLE
Consistently use sandbox for CpsFlowDefinitions

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/global/WorkflowLibRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/global/WorkflowLibRepositoryTest.java
@@ -64,7 +64,8 @@ public class WorkflowLibRepositoryTest {
 
                 p.setDefinition(new CpsFlowDefinition(
                         "o=new foo.Foo().answer()\n" +
-                        "println 'o=' + o;"));
+                        "println 'o=' + o;",
+                        true));
 
                 // get the build going
                 WorkflowRun b = p.scheduleBuild2(0).getStartCondition().get();
@@ -163,7 +164,7 @@ public class WorkflowLibRepositoryTest {
                 FileUtils.writeStringToFile(new File(vars, "block.groovy"), "def call(body) {node {body()}}");
                 uvl.rebuild();
                 WorkflowJob p = jenkins.createProject(WorkflowJob.class, "p");
-                p.setDefinition(new CpsFlowDefinition("block {semaphore 'wait'}"));
+                p.setDefinition(new CpsFlowDefinition("block {semaphore 'wait'}", true));
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();
                 SemaphoreStep.waitForStart("wait/1", b);
             }


### PR DESCRIPTION
While looking at the test suite for this plugin, I noticed the CpsFlowDefinitions in the tests don't consistently use the script security sandbox. Always using the script security sandbox makes the tests consistent with each other, and it's also a more realistic environment given that the script security sandbox should always be enabled in production.

I In this change, I replaced any usages of the deprecated single-argument constructor for `CpsFlowDefinition` with usages of the non-deprecated two-argument constructor, passing in `true` as the second argument in order to enable the script security sandbox.