### PR TITLE
[DO NOT MERGE] Bump workflow-durable-task-step from 2.28 to 2.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.16</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.138.4</jenkins.version>
+        <jenkins.version>2.176.2</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
         <workflow-cps-plugin.version>2.71</workflow-cps-plugin.version>
@@ -169,7 +169,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.28</version>
+            <version>2.32</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -266,6 +266,12 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>branch-api</artifactId>
             <version>2.2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>1.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Demonstrating that `workflow-durable-task-step` _cannot_ be updated to 2.32 successfully. When this update is attempted, `LibraryMemoryTest#loaderReleased` starts failing with the following stack trace:

```
[ERROR] loaderReleased(org.jenkinsci.plugins.workflow.libs.LibraryMemoryTest)  Time elapsed: 1.561 s  <<< ERROR!
java.lang.NullPointerException
	at org.netbeans.insane.live.Path.getField(Path.java:146)
	at org.netbeans.insane.live.Path.toString(Path.java:140)
	at org.netbeans.insane.live.Path.toString(Path.java:138)
	at java.lang.String.valueOf(String.java:2994)
	at java.lang.StringBuilder.append(StringBuilder.java:131)
	at java.util.AbstractMap.toString(AbstractMap.java:559)
	at java.lang.String.valueOf(String.java:2994)
	at java.lang.StringBuilder.append(StringBuilder.java:131)
	at org.jvnet.hudson.test.MemoryAssert.assertGC(MemoryAssert.java:187)
	at org.jenkinsci.plugins.workflow.libs.LibraryMemoryTest.loaderReleased(LibraryMemoryTest.java:85)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:48)
	at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:599)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:298)
	at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:292)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.lang.Thread.run(Thread.java:748)
```