### PR TITLE
[DO NOT MERGE] Bump workflow-durable-task-step from 2.28 to 2.34

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.34-rc982.3a0ab191d81f</version>
+            <version>2.34-rc983.972bd62eceb4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.16</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.138.4</jenkins.version>
+        <jenkins.version>2.176.2</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
         <workflow-cps-plugin.version>2.71</workflow-cps-plugin.version>
@@ -169,7 +169,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.28</version>
+            <version>2.34-rc980.d8ebf86491f3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -266,6 +266,12 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>branch-api</artifactId>
             <version>2.2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>1.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.34-rc981.63207f0d447d</version>
+            <version>2.34-rc982.3a0ab191d81f</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.34-rc980.d8ebf86491f3</version>
+            <version>2.34-rc981.63207f0d447d</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Demonstrating that jenkinsci/workflow-durable-task-step-plugin#117 fixes the problem shown in #81. Note that, like in #81, the branches of the `Jenkinsfile` that run tests in 2.164.1 are expected to fail (for the same reasons as in #81). Without write access to this repository, there is nothing I can do about this. However, the branches of the `Jenkinsfile` that run the tests against the version specified in `pom.xml` (e.g., the `linux-8` branch of the pipeline) — here, 2.176.2 — are expected to pass.