### PR TITLE
Support maven folder layout for src

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/global/GroovyShellDecoratorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/global/GroovyShellDecoratorImpl.java
@@ -29,6 +29,7 @@ public class GroovyShellDecoratorImpl extends GroovyShellDecorator {
                 try {
                     shell.getClassLoader().addURL(new File(repo.workspace,"src").toURI().toURL());
                     shell.getClassLoader().addURL(new File(repo.workspace, UserDefinedGlobalVariable.PREFIX).toURI().toURL());
+                    shell.getClassLoader().addURL(new File(repo.workspace,"src/main/groovy").toURI().toURL());
                 } catch (MalformedURLException e) {
                     throw new AssertionError(e);
                 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
@@ -90,7 +90,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowCopier;
             // Resuming a build, so just look up what we loaded before.
             for (LibraryRecord record : action.getLibraries()) {
                 FilePath libDir = new FilePath(execution.getOwner().getRootDir()).child("libs/" + record.name);
-                for (String root : new String[] {"src", "vars"}) {
+                for (String root : new String[] {"src", "src/main/groovy", "vars"}) {
                     FilePath dir = libDir.child(root);
                     if (dir.isDirectory()) {
                         additions.add(new Addition(dir.toURI().toURL(), record.trusted));
@@ -158,7 +158,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowCopier;
         // Replace any classes requested for replay:
         if (!trusted) {
             for (String clazz : ReplayAction.replacementsIn(execution)) {
-                for (String root : new String[] {"src", "vars"}) {
+                for (String root : new String[] {"src", "src/main/groovy", "vars"}) {
                     String rel = root + "/" + clazz.replace('.', '/') + ".groovy";
                     FilePath f = libDir.child(rel);
                     if (f.exists()) {
@@ -175,6 +175,10 @@ import org.jenkinsci.plugins.workflow.flow.FlowCopier;
         FilePath srcDir = libDir.child("src");
         if (srcDir.isDirectory()) {
             urls.add(srcDir.toURI().toURL());
+        }
+        FilePath srcMavenDir = libDir.child("src/main/groovy");
+        if (srcMavenDir.isDirectory()) {
+            urls.add(srcMavenDir.toURI().toURL());
         }
         FilePath varsDir = libDir.child("vars");
         if (varsDir.isDirectory()) {
@@ -262,7 +266,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowCopier;
                             if (library.trusted) {
                                 continue; // TODO JENKINS-41157 allow replay of trusted libraries if you have RUN_SCRIPTS
                             }
-                            for (String rootName : new String[] {"src", "vars"}) {
+                            for (String rootName : new String[] {"src", "src/main/groovy", "vars"}) {
                                 FilePath root = libs.child(library.name + "/" + rootName);
                                 if (!root.isDirectory()) {
                                     continue;

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/global/WorkflowLibRepositoryLocalTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/global/WorkflowLibRepositoryLocalTest.java
@@ -55,6 +55,11 @@ public class WorkflowLibRepositoryLocalTest extends Assert {
 
         FileUtils.writeStringToFile(f,"package org.acme; def hello() { echo('answer is 42') }");
 
+        f = new File(dir, "src/main/groovy/org/acme/Bar.groovy");
+        f.getParentFile().mkdirs();
+
+        FileUtils.writeStringToFile(f,"package org.acme; def hello() { echo('answer was 42') }");
+
         // commit & push
         git.add().addFilepattern(".").call();
         git.commit().setMessage("Initial commit").call();
@@ -62,9 +67,11 @@ public class WorkflowLibRepositoryLocalTest extends Assert {
 
         // test if this script is accessible from form validation
         WorkflowJob p = j.createProject(WorkflowJob.class);
+        assertEquals(cfdd.doCheckScriptCompile(p, "import org.acme.Bar"), CpsFlowDefinitionValidator.CheckStatus.SUCCESS.asJSON());
         assertEquals(cfdd.doCheckScriptCompile(p, "import org.acme.Foo"), CpsFlowDefinitionValidator.CheckStatus.SUCCESS.asJSON());
         assertNotEquals(cfdd.doCheckScriptCompile(p, "import org.acme.NoSuchThing").toString(), CpsFlowDefinitionValidator.CheckStatus.SUCCESS.asJSON().toString()); // control test
         // valid from script-security point of view
+        assertSame(cfdd.doCheckScript("import org.acme.Bar", true), FormValidation.ok());
         assertSame(cfdd.doCheckScript("import org.acme.Foo", true), FormValidation.ok());
         assertSame(cfdd.doCheckScript("import org.acme.NoSuchThing", true), FormValidation.ok());
     }


### PR DESCRIPTION
## Highlights
- Use the [standard folder layout](https://maven.apache.org/guides/introduction/introduction-to-the-standard-directory-layout.html) to support UTs, ITs and other stages out of the box.
- Even though the `src/main/groovy` is not within the standard layout, I'd say it seems it's the de facto standard.
- Backward compatible.

## Questions
- Not sure what other UTs should be added for this particular feature.

## Tasks
- [ ] Update docs https://github.com/jenkins-infra/jenkins.io/blob/master/content/doc/book/pipeline/shared-libraries.adoc#directory-structure