### PR TITLE
JENKINS-38609, Shared Library non ROOT support - initial implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 target
 work
 .idea
+.classpath
+.project
+.settings

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
@@ -119,8 +119,9 @@ import org.jenkinsci.plugins.workflow.flow.FlowCopier;
                     continue;
                 }
                 String version = cfg.defaultedVersion(libraryVersions.remove(name));
+                String libBasePath = cfg.getLibBasePath();
                 Boolean changelog = cfg.defaultedChangelogs(libraryChangelogs.remove(name));
-                librariesAdded.put(name, new LibraryRecord(name, version, kindTrusted, changelog));
+                librariesAdded.put(name, new LibraryRecord(name, version, libBasePath, kindTrusted, changelog));
                 retrievers.put(name, cfg.getRetriever());
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration.java
@@ -58,10 +58,12 @@ public class LibraryConfiguration extends AbstractDescribableImpl<LibraryConfigu
     private boolean implicit;
     private boolean allowVersionOverride = true;
     private boolean includeInChangesets = true;
+    private String libBasePath;
 
     @DataBoundConstructor public LibraryConfiguration(String name, LibraryRetriever retriever) {
         this.name = name;
         this.retriever = retriever;
+        this.libBasePath = "";
     }
 
     /**
@@ -121,7 +123,20 @@ public class LibraryConfiguration extends AbstractDescribableImpl<LibraryConfigu
         this.includeInChangesets = includeInChangesets;
     }
 
-    @Nonnull boolean defaultedChangelogs(@CheckForNull Boolean changelog) throws AbortException {
+    /**
+     * Library base path.
+     * 
+     * @return the library base path
+     */
+    public String getLibBasePath() {
+		return libBasePath;
+	}
+        
+    @DataBoundSetter public void setLibBasePath(String libBasePath) {
+		this.libBasePath = libBasePath;
+	}
+
+	@Nonnull boolean defaultedChangelogs(@CheckForNull Boolean changelog) throws AbortException {
       if (changelog == null) {
         return includeInChangesets;
       } else {

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRecord.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRecord.java
@@ -34,19 +34,66 @@ final class LibraryRecord {
 
     final String name;
     final String version;
+    final String libBasePath;
     final Set<String> variables = new TreeSet<>();
     final boolean trusted;
     final boolean changelog;
 
-    LibraryRecord(String name, String version, boolean trusted, boolean changelog) {
+    LibraryRecord(String name, String version, String libBasePath, boolean trusted, boolean changelog) {
         this.name = name;
         this.version = version;
+        this.libBasePath = libBasePath;
         this.trusted = trusted;
         this.changelog = changelog;
     }
 
-    @Override public String toString() {
-        return "LibraryRecord{name=" + name + ", version=" + version + ", variables=" + variables + ", trusted=" + trusted + ", changelog=" + changelog + '}';
+    @Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + (changelog ? 1231 : 1237);
+		result = prime * result + ((libBasePath == null) ? 0 : libBasePath.hashCode());
+		result = prime * result + ((name == null) ? 0 : name.hashCode());
+		result = prime * result + (trusted ? 1231 : 1237);
+		result = prime * result + ((version == null) ? 0 : version.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		LibraryRecord other = (LibraryRecord) obj;
+		if (changelog != other.changelog)
+			return false;
+		if (libBasePath == null) {
+			if (other.libBasePath != null)
+				return false;
+		} else if (!libBasePath.equals(other.libBasePath))
+			return false;
+		if (name == null) {
+			if (other.name != null)
+				return false;
+		} else if (!name.equals(other.name))
+			return false;
+		if (trusted != other.trusted)
+			return false;
+		if (version == null) {
+			if (other.version != null)
+				return false;
+		} else if (!version.equals(other.version))
+			return false;
+		return true;
+	}
+
+
+
+	@Override public String toString() {
+        return "LibraryRecord{name=" + name + ", version=" + version + ", libBasePath=" + libBasePath + ", variables=" + variables + ", trusted=" + trusted + ", changelog=" + changelog + '}';
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryStep.java
@@ -164,6 +164,7 @@ public class LibraryStep extends AbstractStepImpl {
         @Override protected LoadedClasses run() throws Exception {
             String[] parsed = LibraryAdder.parse(step.identifier);
             String name = parsed[0], version = parsed[1];
+            String libBasePath = "";
             boolean trusted = false;
             Boolean changelog = step.getChangelog();
             LibraryRetriever retriever = step.getRetriever();
@@ -174,6 +175,7 @@ public class LibraryStep extends AbstractStepImpl {
                             retriever = cfg.getRetriever();
                             trusted = resolver.isTrusted();
                             version = cfg.defaultedVersion(version);
+                            libBasePath = cfg.getLibBasePath();
                             changelog = cfg.defaultedChangelogs(changelog);
                             break;
                         }
@@ -186,7 +188,7 @@ public class LibraryStep extends AbstractStepImpl {
                 throw new AbortException("Must specify a version for library " + name);
             }
 
-            LibraryRecord record = new LibraryRecord(name, version, trusted, changelog);
+            LibraryRecord record = new LibraryRecord(name, version, libBasePath, trusted, changelog);
             LibrariesAction action = run.getAction(LibrariesAction.class);
             if (action == null) {
                 action = new LibrariesAction(Lists.newArrayList(record));

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMRetriever.java
@@ -62,11 +62,11 @@ public class SCMRetriever extends LibraryRetriever {
     }
 
     @Override public void retrieve(String name, String version, boolean changelog, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
-        SCMSourceRetriever.doRetrieve(name, changelog, scm, target, run, listener);
+        SCMSourceRetriever.doRetrieve(name, version, changelog, scm, target, run, listener);
     }
 
     @Override public void retrieve(String name, String version, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
-        SCMSourceRetriever.doRetrieve(name, true, scm, target, run, listener);
+        SCMSourceRetriever.doRetrieve(name, version, true, scm, target, run, listener);
     }
     
     @Override public FormValidation validateVersion(String name, String version, Item context) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
@@ -172,8 +172,7 @@ public class SCMSourceRetriever extends LibraryRetriever {
             } else {
             	String trimedLibBasePath = libBasePath.trim();
             	String libBase = trimedLibBasePath.endsWith("/") ? trimedLibBasePath : trimedLibBasePath + "/";
-            	WorkspaceList.Lease lib = computer.getWorkspaceList().allocate(dir.child(libBase));
-            	lib.path.copyRecursiveTo("src/**/*.groovy,vars/*.groovy,vars/*.txt,resources/", null, target);            	
+		lease.path.child(libBase).copyRecursiveTo("src/**/*.groovy,vars/*.groovy,vars/*.txt,resources/", null, target);
             }
         }
     }

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/config.jelly
@@ -39,6 +39,9 @@ THE SOFTWARE.
     </f:entry>
     <f:entry field="includeInChangesets" title="${%Include @Library changes in job recent changes}">
         <f:checkbox default="true"/>
+    </f:entry>    
+	<f:entry field="libBasePath" title="${%Library base path}">
+        <f:textbox/>
     </f:entry>
     <f:descriptorRadioList varName="retriever" instance="${instance.retriever}" descriptors="${descriptor.retrieverDescriptors}" title="${%Retrieval method}"/>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/help-libBasePath.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration/help-libBasePath.html
@@ -1,0 +1,12 @@
+<div>
+    A relative path, e.g. common/subprojects/sharedlibs/, that will be added to the library path so that the library will be loaded from 
+    "${libBasePath}/src/**/*.groovy", 
+    "${libBasePath}/vars/*.groovy", 
+    "${libBasePath}/vars/*.txt", 
+    "${libBasePath}/resources/".
+    If blank, the library will be loaded from default location under project root of code repository
+    "src/**/*.groovy", 
+    "vars/*.groovy", 
+    "vars/*.txt", 
+    "resources/".
+</div>


### PR DESCRIPTION
This is an implementation for JENKINS-38609, which makes it possible to load libraries from a specified relative path.