### PR TITLE
[JENKINS-38992] add ability to cache shared libraries

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRetriever.java
@@ -35,11 +35,29 @@ import hudson.model.TaskListener;
 import hudson.util.FormValidation;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
+import org.jenkinsci.plugins.workflow.libs.cache.CacheKeyBuilder;
+import org.jenkinsci.plugins.workflow.libs.cache.CacheStorage;
+import org.jenkinsci.plugins.workflow.libs.cache.CacheStorageResult;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * A way in which a library can be physically obtained for use in a build.
  */
 public abstract class LibraryRetriever extends AbstractDescribableImpl<LibraryRetriever> implements ExtensionPoint {
+
+    private SCMCacheConfiguration cache;
+
+    public LibraryRetriever() {
+        // do nothing
+    }
+
+    @DataBoundSetter public void setCache(SCMCacheConfiguration cache) {
+        this.cache = cache;
+    }
+
+    public SCMCacheConfiguration getCache() {
+        return cache;
+    }
 
     /**
      * Obtains library sources.
@@ -51,7 +69,79 @@ public abstract class LibraryRetriever extends AbstractDescribableImpl<LibraryRe
      * @param listener a way to report progress
      * @throws Exception if there is any problem (use {@link AbortException} for user errors)
      */
-    public abstract void retrieve(@Nonnull String name, @Nonnull String version, boolean changelog, @Nonnull FilePath target, @Nonnull Run<?,?> run, @Nonnull TaskListener listener) throws Exception;
+    public void retrieve(@Nonnull String name, @Nonnull String version, boolean changelog, @Nonnull FilePath target, @Nonnull Run<?, ?> run, @Nonnull TaskListener listener) throws Exception {
+        if (isCacheEnabled(version)) {
+            listener.getLogger().println("Caching is enabled");
+
+            String key = new CacheKeyBuilder().name(name).version(version).additionalKey(cache.getAdditionalKey()).build();
+            long ttl = cache.getTtl() * 1000;
+
+            listener.getLogger().println("Cache ID: " + key);
+
+            CacheStorage storage = CacheStorage.get();
+
+            CacheStorageResult<Boolean> result = storage.tryRead(key, entry -> {
+                if (entry.isUpToDate(ttl)) {
+                    listener.getLogger().println("Loading the library from cache...");
+                    entry.copyTo(target);
+                    return true;
+                }
+                listener.getLogger().println("Cached version of the library is outdated/missing");
+                return false;
+            });
+            if (result.isExecuted() && result.getValue()) {
+                return;
+            }
+
+            result = storage.tryWrite(key, entry -> {
+                if (entry.isUpToDate(ttl)) {
+                    // cache is up-to-date so free write lock ASAP and use read lock to access data
+                    return false;
+                }
+                listener.getLogger().println("Retrieving the library...");
+                doRetrieve(name, version, changelog, target, run, listener);
+                listener.getLogger().println("Saving retrieved files in cache...");
+                entry.copyFrom(target);
+                return true;
+            });
+            if (result.isExecuted() && result.getValue()) {
+                return;
+            }
+
+            listener.getLogger().println("Other executor is downloading a fresh version of the library. Waiting...");
+            result = storage.tryRead(key, entry -> {
+                if (entry.isUpToDate(ttl)) {
+                    listener.getLogger().println("Loading the library from cache...");
+                    entry.copyTo(target);
+                    return true;
+                }
+                listener.getLogger().println("Cached version of the library is still outdated...");
+                return false;
+            });
+            if (result.isExecuted() && result.getValue()) {
+                return;
+            }
+
+            listener.getLogger().println("Fallback to non-cache mode");
+        }
+        doRetrieve(name, version, changelog, target, run, listener);
+    }
+
+    protected boolean isCacheEnabled(String version) {
+        return cache != null && cache.getTtl() != 0 && !version.matches(cache.getExcludedVersions());
+    }
+
+    /**
+     * Obtains library sources.
+     * @param name the {@link LibraryConfiguration#getName}
+     * @param version the version of the library, such as from {@link LibraryConfiguration#getDefaultVersion} or an override
+     * @param changelog whether to include changesets in the library in jobs using it from {@link LibraryConfiguration#getIncludeInChangesets}
+     * @param target a directory in which to check out sources; should create {@code src/**}{@code /*.groovy} and/or {@code vars/*.groovy}, and optionally also {@code resources/}
+     * @param run a build which will use the library
+     * @param listener a way to report progress
+     * @throws Exception if there is any problem (use {@link AbortException} for user errors)
+     */
+    protected abstract void doRetrieve(@Nonnull String name, @Nonnull String version, boolean changelog, @Nonnull FilePath target, @Nonnull Run<?, ?> run, @Nonnull TaskListener listener) throws Exception;
 
     /**
      * Obtains library sources.
@@ -61,12 +151,13 @@ public abstract class LibraryRetriever extends AbstractDescribableImpl<LibraryRe
      * @param run a build which will use the library
      * @param listener a way to report progress
      * @throws Exception if there is any problem (use {@link AbortException} for user errors)
+     * @deprecated use {@link #retrieve(String, String, boolean, FilePath, Run, TaskListener)} instead
      */
-    // TODO this should have been made nonabstract and deprecated and delegated to the new version; may be able to use access-modifier to help
-    public abstract void retrieve(@Nonnull String name, @Nonnull String version, @Nonnull FilePath target, @Nonnull Run<?,?> run, @Nonnull TaskListener listener) throws Exception;
+    @Deprecated public void retrieve(@Nonnull String name, @Nonnull String version, @Nonnull FilePath target, @Nonnull Run<?, ?> run, @Nonnull TaskListener listener) throws Exception {
+        retrieve(name, version, true, target, run, listener);
+    }
 
-    @Deprecated
-    public FormValidation validateVersion(@Nonnull String name, @Nonnull String version) {
+    @Deprecated public FormValidation validateVersion(@Nonnull String name, @Nonnull String version) {
         if (Util.isOverridden(LibraryRetriever.class, getClass(), "validateVersion", String.class, String.class, Item.class)) {
             return validateVersion(name, version, null);
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMCacheConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMCacheConfiguration.java
@@ -1,0 +1,108 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.libs;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import hudson.util.FormValidation;
+import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.workflow.libs.cache.CacheKeyBuilder;
+import org.jenkinsci.plugins.workflow.libs.cache.CacheStorage;
+import org.jenkinsci.plugins.workflow.libs.cache.CacheStorageResult;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
+import org.kohsuke.stapler.QueryParameter;
+
+public class SCMCacheConfiguration extends AbstractDescribableImpl<SCMCacheConfiguration> {
+
+    private final int ttl;
+    private String additionalKey;
+    private String excludedVersions;
+
+    @DataBoundConstructor public SCMCacheConfiguration(int ttl) {
+        this.ttl = ttl;
+    }
+
+    public int getTtl() {
+        return ttl;
+    }
+
+    public String getAdditionalKey() {
+        return StringUtils.defaultString(additionalKey);
+    }
+
+    @DataBoundSetter public void setAdditionalKey(String additionalKey) {
+        this.additionalKey = additionalKey;
+    }
+
+    public String getExcludedVersions() {
+        return StringUtils.defaultString(excludedVersions);
+    }
+
+    @DataBoundSetter public void setExcludedVersions(String excludedVersions) {
+        this.excludedVersions = excludedVersions;
+    }
+
+    @Extension public static class DescriptorImpl extends Descriptor<SCMCacheConfiguration> {
+
+        public FormValidation doDeleteCache(@QueryParameter String name, @QueryParameter String defaultVersion, @QueryParameter String additionalKey) {
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+
+            CacheStorage cacheStorage = CacheStorage.get();
+            String key = new CacheKeyBuilder().name(name).version(defaultVersion).additionalKey(additionalKey).build();
+
+            CacheStorageResult<Void> result;
+            try {
+                result = cacheStorage.tryWrite(key, entry -> {
+                    entry.delete();
+                    return null;
+                });
+            } catch (Exception e) {
+                return FormValidation.error(e, "Couldn't delete the cache (id: " + key + ").");
+            }
+
+            if (result.isExecuted()) {
+                return FormValidation.ok("The cache (id: " + key + ") has been sucessfully deleted.");
+            }
+            return FormValidation.ok("The cache (id: " + key + ") is in use and couldn't be deleted.");
+        }
+
+        public FormValidation doForceDeleteCache(@QueryParameter String name, @QueryParameter String defaultVersion, @QueryParameter String additionalKey) {
+            Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+
+            CacheStorage cacheStorage = CacheStorage.get();
+            String key = new CacheKeyBuilder().name(name).version(defaultVersion).additionalKey(additionalKey).build();
+
+            try {
+                cacheStorage.forceDelete(key);
+            } catch (Exception e) {
+                return FormValidation.error(e, "Couldn't delete the cache (id: " + key + ").");
+            }
+            return FormValidation.ok("The cache (id: " + key + ") has been sucessfully deleted.");
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMRetriever.java
@@ -61,14 +61,10 @@ public class SCMRetriever extends LibraryRetriever {
         return scm;
     }
 
-    @Override public void retrieve(String name, String version, boolean changelog, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
+    @Override protected void doRetrieve(String name, String version, boolean changelog, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
         SCMSourceRetriever.doRetrieve(name, changelog, scm, target, run, listener);
     }
 
-    @Override public void retrieve(String name, String version, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
-        SCMSourceRetriever.doRetrieve(name, true, scm, target, run, listener);
-    }
-    
     @Override public FormValidation validateVersion(String name, String version, Item context) {
         if (!Items.XSTREAM2.toXML(scm).contains("${library." + name + ".version}")) {
             return FormValidation.warningWithMarkup("When using <b>" + getDescriptor().getDisplayName() + "</b>, you will need to include <code>${library." + Util.escape(name) + ".version}</code> in the SCM configuration somewhere.");

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
@@ -88,16 +88,12 @@ public class SCMSourceRetriever extends LibraryRetriever {
         return scm;
     }
 
-    @Override public void retrieve(String name, String version, boolean changelog, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
+    @Override protected void doRetrieve(String name, String version, boolean changelog, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
         SCMRevision revision = retrySCMOperation(listener, () -> scm.fetch(version, listener, run.getParent()));
         if (revision == null) {
             throw new AbortException("No version " + version + " found for library " + name);
         }
         doRetrieve(name, changelog, scm.build(revision.getHead(), revision), target, run, listener);
-    }
-
-    @Override public void retrieve(String name, String version, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
-        retrieve(name, version, true, target, run, listener);
     }
 
     private static <T> T retrySCMOperation(TaskListener listener, Callable<T> task) throws Exception{

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/CacheKeyBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/CacheKeyBuilder.java
@@ -1,0 +1,40 @@
+package org.jenkinsci.plugins.workflow.libs.cache;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang.StringUtils;
+
+public class CacheKeyBuilder {
+
+    protected static final String SEPARATOR = "@cache-storage-separator@";
+
+    private String name;
+    private String version;
+    private String additionalKey;
+
+    public CacheKeyBuilder name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public CacheKeyBuilder version(String version) {
+        this.version = version;
+        return this;
+    }
+
+    public CacheKeyBuilder additionalKey(String additionalKey) {
+        this.additionalKey = additionalKey;
+        return this;
+    }
+
+    public String build() {
+        StringBuilder text = new StringBuilder();
+        text.append(name);
+        text.append(SEPARATOR);
+        text.append(version);
+        text.append(SEPARATOR);
+        if (StringUtils.isNotEmpty(additionalKey)) {
+            text.append(additionalKey);
+        }
+        return DigestUtils.sha1Hex(text.toString());
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/CacheStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/CacheStorage.java
@@ -1,0 +1,49 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.libs.cache;
+
+import java.util.Collection;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.libs.cache.impl.FileBasedCacheStorage;
+
+public interface CacheStorage {
+
+    <T> CacheStorageResult<T> tryWrite(String key, CacheStorageWriteAction<T> action) throws Exception;
+
+    <T> CacheStorageResult<T> tryRead(String key, CacheStorageReadAction<T> action) throws Exception;
+
+    Collection<String> getKeys() throws Exception;
+
+    void forceDelete(String key) throws Exception;
+
+    static CacheStorage get() {
+        String clazz = System.getProperty("jenkins.workflow-libs.cacheStorage.implementation", FileBasedCacheStorage.class.getName());
+        try {
+            return (CacheStorage) Jenkins.get().getPluginManager().uberClassLoader.loadClass(clazz).newInstance();
+        } catch (ClassNotFoundException | IllegalAccessException | IllegalStateException | InstantiationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/CacheStorageCleanup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/CacheStorageCleanup.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.libs.cache;
+
+import hudson.Extension;
+import hudson.model.AsyncPeriodicWork;
+import hudson.model.TaskListener;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+@Extension public class CacheStorageCleanup extends AsyncPeriodicWork {
+
+    private static final Logger LOGGER = Logger.getLogger(CacheStorageCleanup.class.getName());
+
+    private final Long recurrencePeriod;
+    private final Long ttl;
+
+    public CacheStorageCleanup() {
+        super(CacheStorageCleanup.class.getSimpleName());
+        recurrencePeriod = Long.getLong("jenkins.workflow-libs.cacheCleanup.recurrencePeriod", TimeUnit.HOURS.toMillis(1));
+        ttl = Long.getLong("jenkins.workflow-libs.cacheCleanup.ttl", TimeUnit.DAYS.toMillis(7));
+    }
+
+    @Override public long getRecurrencePeriod() {
+        return recurrencePeriod;
+    }
+
+    @Override protected void execute(TaskListener listener) {
+        CacheStorage storage = CacheStorage.get();
+        Iterable<String> keys;
+        try {
+            keys = storage.getKeys();
+        } catch (Exception e) {
+            LOGGER.log(Level.SEVERE, "Couldn't access cache storage! Please empty the cache manually from the server.", e);
+            return;
+        }
+        for (String key : keys) {
+            try {
+                // if action is not executed then it means that somebody has the write lock, and the cache entry should be up-to-date (don't delete it)
+                storage.tryWrite(key, entry -> {
+                    if (!entry.isUpToDate(ttl)) {
+                        LOGGER.log(Level.INFO, String.format("\"%s\" cache entry has exceeded TTL, deleting...", key));
+                        entry.delete();
+                        LOGGER.log(Level.INFO, String.format("Deleted \"%s\" cache entry", key));
+                    }
+                    return null;
+                });
+            } catch (Exception e) {
+                LOGGER.log(Level.SEVERE, String.format("Couldn't process \"%s\" cache entry", key), e);
+            }
+        }
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/CacheStorageReadAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/CacheStorageReadAction.java
@@ -1,0 +1,30 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.libs.cache;
+
+public interface CacheStorageReadAction<T> {
+
+    T execute(ReadOnlyCacheEntry entry) throws Exception;
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/CacheStorageResult.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/CacheStorageResult.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.libs.cache;
+
+public class CacheStorageResult<T> {
+
+    private final boolean executed;
+    private final T value;
+
+    public CacheStorageResult(boolean executed, T value) {
+        this.executed = executed;
+        this.value = value;
+    }
+
+    public boolean isExecuted() {
+        return executed;
+    }
+
+    public T getValue() {
+        return value;
+    }
+
+    public static <T> CacheStorageResult<T> notExecuted() {
+        return new CacheStorageResult<>(false, null);
+    }
+
+    public static <T> CacheStorageResult<T> executed(T value) {
+        return new CacheStorageResult<T>(true, value);
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/CacheStorageWriteAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/CacheStorageWriteAction.java
@@ -1,0 +1,30 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.libs.cache;
+
+public interface CacheStorageWriteAction<T> {
+
+    T execute(WritableCacheEntry entry) throws Exception;
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/ReadOnlyCacheEntry.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/ReadOnlyCacheEntry.java
@@ -1,0 +1,36 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.libs.cache;
+
+import hudson.FilePath;
+
+public interface ReadOnlyCacheEntry {
+
+    boolean isUpToDate(long ttl) throws Exception;
+
+    long getLastModified() throws Exception;
+
+    void copyTo(FilePath dest) throws Exception;
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/WritableCacheEntry.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/WritableCacheEntry.java
@@ -1,0 +1,34 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.libs.cache;
+
+import hudson.FilePath;
+
+public interface WritableCacheEntry extends ReadOnlyCacheEntry {
+
+    void copyFrom(FilePath src) throws Exception;
+
+    void delete() throws Exception;
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/impl/FileBasedCacheEntry.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/impl/FileBasedCacheEntry.java
@@ -1,0 +1,87 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.libs.cache.impl;
+
+import hudson.FilePath;
+import java.io.IOException;
+import org.jenkinsci.plugins.workflow.libs.cache.WritableCacheEntry;
+
+public class FileBasedCacheEntry implements WritableCacheEntry {
+
+    private static final int LAST_MODIFIED_OF_NONEXISTENT_ENTRY = -1;
+
+    private final FilePath rootDir;
+    private final FilePath timestampMarker;
+    private final FilePath dataDir;
+
+    public FileBasedCacheEntry(FilePath rootDir) {
+        this.rootDir = rootDir;
+        timestampMarker = new FilePath(rootDir, "timestamp.txt");
+        dataDir = new FilePath(rootDir, "data");
+    }
+
+    @Override public boolean isUpToDate(long ttl) throws IOException, InterruptedException {
+        long lastModified = getLastModified();
+        if (lastModified == LAST_MODIFIED_OF_NONEXISTENT_ENTRY) {
+            return false;
+        }
+        if (ttl < 0) {
+            return true;
+        }
+        return System.currentTimeMillis() - lastModified < ttl;
+    }
+
+    @Override public long getLastModified() throws IOException, InterruptedException {
+        if (timestampMarker.exists()) {
+            return timestampMarker.lastModified();
+        }
+        return LAST_MODIFIED_OF_NONEXISTENT_ENTRY;
+    }
+
+    @Override public void copyTo(FilePath dest) throws IOException, InterruptedException {
+        copy(dataDir, dest);
+    }
+
+    @Override public void copyFrom(FilePath src) throws IOException, InterruptedException {
+        copy(src, dataDir);
+        timestampMarker.touch(System.currentTimeMillis());
+    }
+
+    protected void copy(FilePath src, FilePath dest) throws IOException, InterruptedException {
+        if (!src.exists()) {
+            throw new IOException(String.format("Cannot copy %s to %s because the source directory does not exist", src.getRemote(), dest.getRemote()));
+        }
+        if (dest.exists()) {
+            dest.deleteRecursive();
+        }
+        src.copyRecursiveTo(dest);
+    }
+
+    @Override public void delete() throws IOException, InterruptedException {
+        dataDir.deleteRecursive();
+        // delete metadata after deletion of data (which could be heavy)
+        rootDir.deleteRecursive();
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/impl/FileBasedCacheStorage.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/impl/FileBasedCacheStorage.java
@@ -1,0 +1,150 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.libs.cache.impl;
+
+import hudson.FilePath;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.workflow.libs.cache.CacheStorage;
+import org.jenkinsci.plugins.workflow.libs.cache.CacheStorageReadAction;
+import org.jenkinsci.plugins.workflow.libs.cache.CacheStorageResult;
+import org.jenkinsci.plugins.workflow.libs.cache.CacheStorageWriteAction;
+
+public class FileBasedCacheStorage implements CacheStorage {
+
+    public static final String CACHE_DIR = "global-libraries-cache";
+
+    private static final String WRITE_LOCK_FILE_NAME = "write.lock";
+    private static final String READ_LOCKS_DIR_NAME = "readLocks";
+
+    private final FilePath cacheDir;
+
+    private final int waitForReleaseReadLocksTries;
+    private final long pausesBetweenWaitingForReleaseReadLocks;
+    private final int waitForReadLockTries;
+    private final long pausesBetweenWaitingForReadLocks;
+
+    public FileBasedCacheStorage() {
+        cacheDir = new FilePath(Jenkins.get().getRootPath(), CACHE_DIR);
+        waitForReleaseReadLocksTries = Integer.getInteger("jenkins.workflow-libs.fileBasedCacheStorage.waitForReleaseReadLocks", 18);
+        pausesBetweenWaitingForReleaseReadLocks = Long.getLong("jenkins.workflow-libs.fileBasedCacheStorage.pausesBetweenWaitingForReleaseReadLocks", TimeUnit.SECONDS.toMillis(10));
+        waitForReadLockTries = Integer.getInteger("jenkins.workflow-libs.fileBasedCacheStorage.waitForReadLockTries", 36);
+        pausesBetweenWaitingForReadLocks = Long.getLong("jenkins.workflow-libs.fileBasedCacheStorage.pausesBetweenWaitingForReadLocks", TimeUnit.SECONDS.toMillis(5));
+    }
+
+    @Override public <T> CacheStorageResult<T> tryWrite(String key, CacheStorageWriteAction<T> action) throws Exception {
+        final FileBasedLock lock = tryWriteLock(key);
+        if (lock != null) {
+            try {
+                return CacheStorageResult.executed(action.execute(getEntry(key)));
+            } finally {
+                lock.release();
+            }
+        }
+        return CacheStorageResult.notExecuted();
+    }
+
+    protected FileBasedLock tryWriteLock(String key) throws IOException, InterruptedException {
+        FilePath writeLock = createFilePath(key, WRITE_LOCK_FILE_NAME);
+        if (writeLock.exists()) {
+            return null;
+        }
+        writeLock.getParent().mkdirs();
+        writeLock.touch(System.currentTimeMillis());
+        FileBasedLock lock = new FileBasedLock(writeLock);
+        try {
+            if (waitForReleaseReadLocks(key)) {
+                return lock;
+            }
+        } catch (Exception e) {
+            // do nothing
+        }
+        lock.release();
+        return null;
+    }
+
+    protected boolean waitForReleaseReadLocks(String key) throws IOException, InterruptedException {
+        FilePath readLocks = createFilePath(key, READ_LOCKS_DIR_NAME);
+        for (int i = 0; i <= waitForReleaseReadLocksTries; ++i) {
+            if (readLocks.list().isEmpty()) {
+                return true;
+            }
+            Thread.sleep(pausesBetweenWaitingForReleaseReadLocks);
+        }
+        return false;
+    }
+
+    @Override public <T> CacheStorageResult<T> tryRead(String key, CacheStorageReadAction<T> action) throws Exception {
+        final FileBasedLock lock = tryReadLock(key);
+        if (lock != null) {
+            try {
+                return CacheStorageResult.executed(action.execute(getEntry(key)));
+            } finally {
+                lock.release();
+            }
+        }
+        return CacheStorageResult.notExecuted();
+    }
+
+    protected FileBasedLock tryReadLock(String key) throws IOException, InterruptedException {
+        FilePath readLocksDir = createFilePath(key, READ_LOCKS_DIR_NAME);
+        FilePath readLock = createFilePath(key, READ_LOCKS_DIR_NAME, UUID.randomUUID().toString());
+        FilePath writeLock = createFilePath(key, WRITE_LOCK_FILE_NAME);
+        for (int i = 0; i < waitForReadLockTries; ++i) {
+            if (!writeLock.exists()) {
+                readLocksDir.mkdirs();
+                readLock.touch(System.currentTimeMillis());
+                return new FileBasedLock(readLock);
+            }
+            Thread.sleep(pausesBetweenWaitingForReadLocks);
+        }
+        return null;
+    }
+
+    @Override public Collection<String> getKeys() throws IOException, InterruptedException {
+        Collection<String> keys = new LinkedList<>();
+        for (FilePath directory : cacheDir.listDirectories()) {
+            keys.add(directory.getName());
+        }
+        return keys;
+    }
+
+    @Override public void forceDelete(String key) throws IOException, InterruptedException {
+        getEntry(key).delete();
+    }
+
+    protected FileBasedCacheEntry getEntry(String key) throws IOException, InterruptedException {
+        FilePath entryDir = createFilePath(key);
+        return new FileBasedCacheEntry(entryDir);
+    }
+
+    protected FilePath createFilePath(String... paths) {
+        return new FilePath(cacheDir, String.join("/", paths));
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/impl/FileBasedLock.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/cache/impl/FileBasedLock.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2016 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.libs.cache.impl;
+
+import hudson.FilePath;
+import java.io.IOException;
+
+public class FileBasedLock {
+
+    private final FilePath lock;
+
+    public FileBasedLock(FilePath lock) {
+        this.lock = lock;
+    }
+
+    public void release() throws IOException, InterruptedException {
+        lock.delete();
+    }
+}

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMCacheConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMCacheConfiguration/config.jelly
@@ -25,6 +25,15 @@ THE SOFTWARE.
 
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:descriptorRadioList varName="scm" instance="${instance.scm}" descriptors="${descriptor.SCMDescriptors}" title="${%Source Code Management}"/>
-    <f:optionalProperty field="cache" title="${%Cache Configuration}"/>
+    <f:entry field="ttl" title="${%Time-To-Live}">
+        <f:number default="900" />
+    </f:entry>
+    <f:entry field="additionalKey" title="${%Additional Key}">
+        <f:textbox />
+    </f:entry>
+    <f:entry field="excludedVersions" title="${%Excluded Versions RegEx}">
+        <f:textbox />
+    </f:entry>
+    <f:validateButton title="${%Delete Cache}" progress="${%Deleting...}" method="deleteCache" with="name,defaultVersion,additionalKey" />
+    <f:validateButton title="${%Forcibly Delete Cache}" progress="${%Forcibly deleting...}" method="forceDeleteCache" with="name,defaultVersion,additionalKey" />
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever/config.jelly
@@ -26,4 +26,5 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:descriptorRadioList varName="scm" instance="${instance.scm}" descriptors="${descriptor.SCMDescriptors}" title="${%Source Code Management}"/>
+    <f:optionalProperty field="cache" title="${%Cache Configuration}"/>
 </j:jelly>


### PR DESCRIPTION
Hello,
We hit the same problem like [Julien Duchesne](/julienduchesne) in #50 . We have a lot of jobs which use our library. Unfortunately, too many requests to our git server ends with 403 permission denied (our server classifies our requests as DOS 😉). I analyzed the comments in #50 and tried to prepare a new implementation proposal.

How it works:
* for cache entries TTL is used to determine when they should be removed/refreshed (it means how long the cache is valid). It works differently than in #50 because it uses creation time instead of access time
* the operation responsible for reading cache are in `LibraryRetriever` (as was suggested in #50). It means it works for libraries added in Jenkins panel and loaded by `library` step (developers are able to set `additionalKey` to prevents overwriting cache by different git libraries)
* file locking mechanism has been introduced to manage the cache properly when a lot of jobs are executed at the same time. It works differently than in #50 which fallback to non-cache mode ASAP. In this proposal one slave will download the library, and all other will use it. An example:
  * we have 3 slaves (1, 2, 3), which are executed at the same time
  * 1 and 2 try to read the cache, cache is outdated so they try to update the cache (first read)
  * 2 tries to get the write lock, and get it, it starts updating the cache (write)
  * 1 tries to get the write lock, but it is taken by 2, so they are waiting for the read lock one more time (second read)
  * 3 tries to get the first read lock, but write operation is in progress, so it is waiting (first read)
  * 2 has finished updating the library, loads it and ends the job
  * 1 tries to get the read lock, it is available, so it reads the cache and ends (second read)
  * 3 tries to get the read lock, it is available, so it reads the cache and ends (first read)
* if slaves are not able to read cache, then they will fallback to non-cache mode
* it is possible to define which versions should be excluded from caching by using regular expression (as was suggested in #50)
* all parameters related to polling (waiting for locks), cleaning (delete all entries), and cache storage implementation are configurable

Stuff to improve:
* in #50 was proposed to add `SCM#getKey` to cache entry id, I didn't do it because it is available only for `legacySCM`. Modern provides only `SCMSource#getId` which according to documentation does not guarantee to return the same values for the same repositories. Please let me know what should I do? I can add both or add it only for `legacySCM`
* ~~we use Kubernetes, and I see that library is always downloaded before the slave container is created. It sounds to me that libraries are always downloaded by code executed on master. If this is true, then I should be able to remove locking based on files and use Java locks. What do you think?~~

Missing stuff:
* I didn't write tests and documentation because I don't know if you accept the main idea. If you think it has potential and could be merged, then I'll add all missing stuff (now we are testing it on our live system 😉 )
* the commit message is ugly, but I'll add a nice detailed message if you accept the main idea

Comments:
We are testing it now on environment which for a single build schedules additional 120 jobs. All those jobs need our library. The cache works quite stable for TTL >= 30 seconds, for TTL = 3 seconds it switches a lot of time to non-cache mode. We haven't hit a problem with broken cache yet (it is possible when two threads ask for a write lock exactly at the same time, and next write to the same directory).

Please let me know what should I improve. We really needs this feature, so we have capacity for adjusting the PR to your comments.

Kind regards