### PR TITLE
[JENKINS-60245] Potential fix for @Library annotation in load()'d scripts

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/ClasspathAdder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/ClasspathAdder.java
@@ -27,9 +27,10 @@ package org.jenkinsci.plugins.workflow.libs;
 import groovy.lang.GroovyShell;
 import hudson.ExtensionPoint;
 import java.net.URL;
-import java.util.List;
 import java.util.HashMap;
+import java.util.List;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 
 /**
@@ -58,12 +59,20 @@ public abstract class ClasspathAdder implements ExtensionPoint {
     }
 
     /**
+     * @see #add(String, CpsFlowExecution, List, HashMap)
+     */
+    public @Nonnull List<Addition> add(@Nonnull CpsFlowExecution execution, @Nonnull List<String> libraries, @Nonnull HashMap<String, Boolean> changelogs) throws Exception {
+        return add( null, execution, libraries, changelogs );
+    }
+    
+    /**
      * May add to the classpath.
+     * @param scope identifier for the source file that the addition came from
      * @param execution a running build (possibly newly started, possibly resumed)
      * @param libraries aggregated entries from all encountered {@link Library#value} (will be empty if {@link Library} is never used at all); an implementation should remove entries it “claims”
      * @return a possibly empty list of additions
      * @throws Exception for whatever reason (will fail compilation)
      */
-    public abstract @Nonnull List<Addition> add(@Nonnull CpsFlowExecution execution, @Nonnull List<String> libraries, @Nonnull HashMap<String, Boolean> changelogs) throws Exception;
+    public abstract @Nonnull List<Addition> add(@Nullable String scope, @Nonnull CpsFlowExecution execution, @Nonnull List<String> libraries, @Nonnull HashMap<String, Boolean> changelogs) throws Exception;
 
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibrariesAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibrariesAction.java
@@ -39,8 +39,15 @@ import java.util.List;
 class LibrariesAction extends InvisibleAction {
 
     private final List<LibraryRecord> libraries;
-
+    
+    private final String scope;
+    
     LibrariesAction(List<LibraryRecord> libraries) {
+        this(null, libraries);
+    }
+
+    LibrariesAction(String scope, List<LibraryRecord> libraries) {
+        this.scope = scope;
         this.libraries = libraries;
     }
 
@@ -49,6 +56,13 @@ class LibrariesAction extends InvisibleAction {
      */
     public List<LibraryRecord> getLibraries() {
         return libraries;
+    }
+    
+    /**
+     * @return An identifier of the source file that these library definitions are for
+     */
+    public String getScope() {
+        return scope;
     }
 
     @Extension public static class LibraryEnvironment extends EnvironmentContributor {

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryDecorator.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryDecorator.java
@@ -122,7 +122,7 @@ import org.jenkinsci.plugins.workflow.cps.GroovyShellDecorator;
                 }.visitClass(classNode);
                 try {
                     for (ClasspathAdder adder : ExtensionList.lookup(ClasspathAdder.class)) {
-                        for (ClasspathAdder.Addition addition : adder.add(execution, libraries, changelogs)) {
+                        for (ClasspathAdder.Addition addition : adder.add(source.getName(), execution, libraries, changelogs)) {  
                             addition.addTo(execution);
                         }
                     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryStep.java
@@ -187,7 +187,15 @@ public class LibraryStep extends AbstractStepImpl {
             }
 
             LibraryRecord record = new LibraryRecord(name, version, trusted, changelog);
-            LibrariesAction action = run.getAction(LibrariesAction.class);
+            LibrariesAction action = null;
+            
+            for( LibrariesAction laction : run.getActions(LibrariesAction.class)) {
+                if( null == laction.getScope() ) {
+                    action = laction;
+                    break;
+                }
+            }
+            
             if (action == null) {
                 action = new LibrariesAction(Lists.newArrayList(record));
                 run.addAction(action);

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryDecoratorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryDecoratorTest.java
@@ -68,7 +68,7 @@ public class LibraryDecoratorTest {
     }
 
     @TestExtension public static class TestAdder extends ClasspathAdder {
-        @Override public List<Addition> add(CpsFlowExecution execution, List<String> libraries, HashMap<String, Boolean> changelogs) throws Exception {
+        @Override public List<Addition> add(String scope, CpsFlowExecution execution, List<String> libraries, HashMap<String, Boolean> changelogs) throws Exception {
             List<Addition> additions = new ArrayList<>();
             for (String library : libraries) {
                 additions.add(new Addition(new File(((WorkflowRun) execution.getOwner().getExecutable()).getParent().getRootDir(), "libs/" + library).toURI().toURL(), false));
@@ -101,7 +101,7 @@ public class LibraryDecoratorTest {
         r.assertLogContains("failed to load [stuff]", r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0)));
     }
     @TestExtension("adderError") public static class ErroneousAdder extends ClasspathAdder {
-        @Override public List<Addition> add(CpsFlowExecution execution, List<String> libraries, HashMap<String, Boolean> changelogs) throws Exception {
+        @Override public List<Addition> add(String scope, CpsFlowExecution execution, List<String> libraries, HashMap<String, Boolean> changelogs) throws Exception {
             throw new AbortException("failed to load " + libraries);
         }
     }


### PR DESCRIPTION
This is a potential fix for the issue described in [JENKINS-60245](https://issues.jenkins-ci.org/browse/JENKINS-60245). I call it a "potential" fix because while it seems to fix all the broken use-cases and cause no regressions, I am not sure if there is a more architecturally-sound means to accomplish the same ends.

Please see the JIRA issue for a complete description of the problem.

These changes add a `String scope` to `LibrariesAction`, and attach one action to a build _per loaded script_.

When recording shared libraries that were mentioned in a `@Library` annotation, the script being processed is used as the scope of the `LibrariesAction`. This enables the plugin to know that it should index the contents of `@Library` annotations in newly-loaded scripts.

When processing libraries to actually add their resources to the classpath, every `LibrariesAction` for the build is iterated over.

This allows scripts loaded with the `load(...)` step to add shared libraries with the `@Library(...)` annotation.

I had to _update_ some existing unit tests, but did not write a regression test for the new behavior. If this implementation of a solution to JENKINS-60245 is determined to be generally-sound & on-track for merging into the plugin, I will write such a test.