### PR TITLE
Bump plugin parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,6 +70,7 @@
         <workflow-cps-plugin.version>2.71</workflow-cps-plugin.version>
         <git-plugin.version>4.0.0-rc</git-plugin.version>
         <scm-api-plugin.version>2.6.3</scm-api-plugin.version>
+        <subversion-plugin.version>2.13.0</subversion-plugin.version>
         <workflow-scm-step-plugin.version>2.7</workflow-scm-step-plugin.version>
         <workflow-multibranch-plugin.version>2.21</workflow-multibranch-plugin.version>
         <workflow-step-api-plugin.version>2.20</workflow-step-api-plugin.version>
@@ -228,20 +229,20 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
-            <version>2.7.1</version>
+            <version>${subversion-plugin.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
-            <version>2.7.1</version>
+            <version>${subversion-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.tmatesoft.svnkit</groupId>
             <artifactId>svnkit-cli</artifactId>
-            <version>1.8.14</version>
+            <version>1.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Shared Groovy Libraries</name>
-    <url>https://wiki.jenkins.io/display/JENKINS/Pipeline+Shared+Groovy+Libraries+Plugin</url>
+    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
     <licenses>
         <license>
             <name>MIT License</name>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Shared Groovy Libraries</name>
-    <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
+    <url>https://wiki.jenkins.io/display/JENKINS/Pipeline+Shared+Groovy+Libraries+Plugin</url>
     <licenses>
         <license>
             <name>MIT License</name>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.50</version>
+        <version>3.54</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
Bumps the [plugin parent POM](https://github.com/jenkinsci/plugin-pom) from 3.50 to 3.54.

See [the changelog](https://github.com/jenkinsci/plugin-pom/releases) and the full diff in [the compare view](https://github.com/jenkinsci/plugin-pom/compare/plugin-3.50...plugin-3.54).