### PR TITLE
Adapt tests affected by fixes for SECURITY-1713

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.60</version>
+            <version>1.70</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/global/GrapeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/global/GrapeTest.java
@@ -197,7 +197,7 @@ public class GrapeTest {
                     "new ArrayIntList()", true));
                 // Even assuming signature approvals, we do not want to allow Grape to be used from sandboxed scripts.
                 ScriptApproval.get().approveSignature("new org.apache.commons.collections.primitives.ArrayIntList");
-                story.j.assertLogContains("WorkflowScript: 1: unable to resolve class org.apache.commons.collections.primitives.ArrayIntList", story.j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0)));
+                story.j.assertLogContains("Annotation Grab cannot be used in the sandbox", story.j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0)));
             }
         });
     }

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/FolderLibrariesTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/FolderLibrariesTest.java
@@ -183,7 +183,7 @@ public class FolderLibrariesTest {
         WorkflowJob p = d.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("@Library('grape@master') import pkg.Wrapper; echo(/should not have been able to run ${pkg.Wrapper.list()}/)", true));
         ScriptApproval.get().approveSignature("new org.apache.commons.collections.primitives.ArrayIntList");
-        r.assertLogContains("Wrapper.groovy: 2: unable to resolve class org.apache.commons.collections.primitives.ArrayIntList", r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0)));
+        r.assertLogContains("Annotation Grab cannot be used in the sandbox", r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0)));
     }
 
     @Issue("JENKINS-43019")


### PR DESCRIPTION
Fixes issues when running this plugin in the PCT as seen in https://github.com/jenkinsci/bom/pull/189.

Previously, the use of `@Grab` did not cause the scripts in these tests to fail until runtime, but after the fixes for SECURITY-1713, the scripts now fail at compile time with a different error message.