### PR TITLE
Exclude src/test/ from shared libraries by default

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
@@ -160,6 +160,10 @@ public class SCMSourceRetriever extends LibraryRetriever {
             // Cannot add WorkspaceActionImpl to private CpsFlowExecution.flowStartNodeActions; do we care?
             // Copy sources with relevant files from the checkout:
             String excludes = INCLUDE_SRC_TEST_IN_LIBRARIES ? null : "src/test/";
+            if (lease.path.child("src/test").exists()) {
+                listener.getLogger().println("Excluding src/test/ from checkout of " + scm.getKey() + " so that shared library test code cannot be accessed by Pipelines.");
+                listener.getLogger().println("To remove this log message, move the test code outside of src/. To restore the previous behavior that allowed access to files in src/test/, pass -D" + SCMSourceRetriever.class.getName() + ".INCLUDE_SRC_TEST_IN_LIBRARIES=true to the java command used to start Jenkins.");
+            }
             lease.path.copyRecursiveTo("src/**/*.groovy,vars/*.groovy,vars/*.txt,resources/", excludes, target);
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever.java
@@ -72,6 +72,9 @@ import org.kohsuke.stapler.DataBoundConstructor;
  */
 public class SCMSourceRetriever extends LibraryRetriever {
 
+    @SuppressFBWarnings(value="MS_SHOULD_BE_FINAL", justification="Non-final for write access via the Script Console")
+    public static boolean INCLUDE_SRC_TEST_IN_LIBRARIES = Boolean.getBoolean(SCMSourceRetriever.class.getName() + ".INCLUDE_SRC_TEST_IN_LIBRARIES");
+
     private final SCMSource scm;
 
     @DataBoundConstructor public SCMSourceRetriever(SCMSource scm) {
@@ -156,7 +159,8 @@ public class SCMSourceRetriever extends LibraryRetriever {
             });
             // Cannot add WorkspaceActionImpl to private CpsFlowExecution.flowStartNodeActions; do we care?
             // Copy sources with relevant files from the checkout:
-            lease.path.copyRecursiveTo("src/**/*.groovy,vars/*.groovy,vars/*.txt,resources/", null, target);
+            String excludes = INCLUDE_SRC_TEST_IN_LIBRARIES ? null : "src/test/";
+            lease.path.copyRecursiveTo("src/**/*.groovy,vars/*.groovy,vars/*.txt,resources/", excludes, target);
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/global/CompilationErrorsExceptionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/global/CompilationErrorsExceptionTest.java
@@ -28,14 +28,14 @@ public class CompilationErrorsExceptionTest {
     @Issue("JENKINS-40109")
     @Test public void errorInSrcStaticLibrary() throws Exception {
         sampleRepo.init();
-        sampleRepo.write("src/test/Test.groovy", "package test; public class Test { bad syntax } ");
+        sampleRepo.write("src/foo/Test.groovy", "package foo; public class Test { bad syntax } ");
         sampleRepo.git("add", "src");
         sampleRepo.git("commit", "--message=init");
         GlobalLibraries.get().setLibraries(Collections.singletonList(
                 new LibraryConfiguration("badlib", new SCMSourceRetriever(new GitSCMSource(sampleRepo.toString())))));
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("@Library('badlib@master')\n" +
-                "import test.Test;", true));
+                "import foo.Test;", true));
         WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
         r.assertLogNotContains(NotSerializableException.class.getName(), b);
         // We don't care about the type of exception thrown here because it happens outside of CPS execution.
@@ -45,7 +45,7 @@ public class CompilationErrorsExceptionTest {
     @Issue("JENKINS-40109")
     @Test public void errorInSrcDynamicLibrary() throws Exception {
         sampleRepo.init();
-        sampleRepo.write("src/test/Test.groovy", "package test; public class Test { bad syntax } ");
+        sampleRepo.write("src/foo/Test.groovy", "package foo; public class Test { bad syntax } ");
         sampleRepo.git("add", "src");
         sampleRepo.git("commit", "--message=init");
         GlobalLibraries.get().setLibraries(Collections.singletonList(
@@ -53,7 +53,7 @@ public class CompilationErrorsExceptionTest {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("def lib = library('badlib@master')\n" +
                 "try {\n" +
-                "  lib.test.Test.new()\n" +
+                "  lib.foo.Test.new()\n" +
                 "} catch(err) {\n" +
                 "  sleep(time: 1, unit: 'MILLISECONDS')\n" + // Force the exception to be persisted.
                 "  throw err\n" +

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryAdderTest.java
@@ -366,6 +366,7 @@ public class LibraryAdderTest {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
         p.setDefinition(new CpsFlowDefinition("@Library('lib@master') import test.Foo", true));
         WorkflowRun b = r.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
+        r.assertLogContains("Excluding src/test/ from checkout", b);
         r.assertLogContains("expected to contain at least one of src or vars directories", b);
     }
 


### PR DESCRIPTION
#83 brought to my attention that some users are putting test code for their shared libraries in `src/test`, mostly when using https://github.com/jenkinsci/JenkinsPipelineUnit, which is not a good idea, since it means that the test code is available to Pipelines using the library. To help users who might have made this mistake accidentally (e.g. `pipeline-library` before https://github.com/jenkins-infra/pipeline-library/pull/138), this PR makes it so that `src/test` is specifically excluded when a shared library is checked out.

In case users were actually using a a package named `test` in their shared library, there is a system property that can be set as an escape hatch to restore the previous behavior.