### PR TITLE
Bump commons-lang3 version to 3.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.7</version>
+            <version>3.9</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>


### PR DESCRIPTION
Sync it with the testharness-html-unit version,
Otherwise we get conflicts on bom

error when introducing 4.x parent pom in bom:
```
Require upper bound dependencies error for org.apache.commons:commons-lang3:3.7 paths to dependency are:
+-io.jenkins.tools.bom:sample:7-SNAPSHOT
  +-org.jenkins-ci.plugins.workflow:workflow-cps-global-lib:2.15
    +-org.apache.commons:commons-lang3:3.7
and
+-io.jenkins.tools.bom:sample:7-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-test-harness:2.62
    +-org.jenkins-ci.main:jenkins-test-harness-htmlunit:2.36.0-1
      +-org.apache.commons:commons-lang3:3.9
and
+-io.jenkins.tools.bom:sample:7-SNAPSHOT
  +-org.jenkins-ci.main:jenkins-test-harness:2.62
    +-org.jenkins-ci.main:jenkins-test-harness-htmlunit:2.36.0-1
      +-org.apache.commons:commons-text:1.7
        +-org.apache.commons:commons-lang3:3.9
```

Very similar error here:
https://github.com/jenkinsci/bom/pull/206

Thoughts?
@jglick @dwnusbaum @bitwiseman 