### PR TITLE
JENKINS-38609: Shared Library non ROOT support

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMRetriever/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMRetriever/config.jelly
@@ -26,4 +26,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:descriptorRadioList varName="scm" instance="${instance.scm}" descriptors="${descriptor.SCMDescriptors}" title="${%Source Code Management}"/>
+	<f:entry field="libBasePath" title="${%Library base path}">
+        <f:textbox checkMethod="post"/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever/config.jelly
@@ -26,4 +26,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:descriptorRadioList varName="scm" instance="${instance.scm}" descriptors="${descriptor.SCMDescriptors}" title="${%Source Code Management}"/>
+	<f:entry field="libBasePath" title="${%Library base path}">
+        <f:textbox checkMethod="post"/>
+    </f:entry>
 </j:jelly>


### PR DESCRIPTION
This is a new implementation for JENKINS-38609, which makes it possible to load libraries from a specified relative path. Only touching files mentioned in review of #84 
