### PR TITLE
[JENKINS-41037] Prevent ConcurrentModificationException serializing LibrariesAction.libraries

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibrariesAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibrariesAction.java
@@ -31,6 +31,7 @@ import hudson.model.InvisibleAction;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -48,7 +49,7 @@ class LibrariesAction extends InvisibleAction {
      * A list of libraries in use.
      */
     public List<LibraryRecord> getLibraries() {
-        return libraries;
+        return Collections.unmodifiableList(libraries);
     }
 
     @Extension public static class LibraryEnvironment extends EnvironmentContributor {

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryStep.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryStep.java
@@ -48,6 +48,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.security.CodeSource;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -197,7 +198,9 @@ public class LibraryStep extends AbstractStepImpl {
                         return new LoadedClasses(name, trusted, changelog, run);
                     }
                 }
-                libraries.add(record);
+                List<LibraryRecord> newLibraries = new ArrayList<>(libraries);
+                newLibraries.add(record);
+                run.replaceAction(new LibrariesAction(newLibraries));
             }
             listener.getLogger().println("Loading library " + record.name + "@" + record.version);
             CpsFlowExecution exec = (CpsFlowExecution) getContext().get(FlowExecution.class);


### PR DESCRIPTION
Should solve the cases of [JENKINS-41037](https://issues.jenkins-ci.org/browse/JENKINS-41037) associated with the `libraries` step, which is most of them. Alternative to https://github.com/x-stream/xstream/pull/222. Not tested (do not know how to reproduce problem).

Note that `CopyOnWriteList` is an alternative fix, for cases where it would be awkward to make the collection immutable, but in this case there is only one piece of code that was ever mutating this list so it is most straightforward to fix that.