### PR TITLE
Fix git snippet test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,7 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
             <scope>test</scope>
+            <version>4.6.0</version> <!-- Temporary version number until it is included in the Jenkins bom -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
     <properties>
         <revision>2.18</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.176.4</jenkins.version>
+        <jenkins.version>2.222.4</jenkins.version>
         <java.level>8</java.level>
         <useBeta>true</useBeta>
         <subversion-plugin.version>2.13.0</subversion-plugin.version>
@@ -74,8 +74,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.176.x</artifactId>
-                <version>7</version>
+                <artifactId>bom-2.222.x</artifactId>
+                <version>23</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryStepTest.java
@@ -81,10 +81,10 @@ public class LibraryStepTest {
         assertEquals("library identifier: 'foo@master', retriever: modernSCM([$class: 'GitSCMSource', credentialsId: '', remote: 'https://nowhere.net/', traits: [gitBranchDiscovery()]])", Snippetizer.object2Groovy(s));
         s.setRetriever(new SCMRetriever(new GitSCM(Collections.singletonList(new UserRemoteConfig("https://nowhere.net/", null, null, null)),
             Collections.singletonList(new BranchSpec("${library.foo.version}")),
-            false, Collections.<SubmoduleConfig>emptyList(), null, null, Collections.<GitSCMExtension>emptyList())));
+            null, null, Collections.<GitSCMExtension>emptyList())));
         s.setChangelog(false);
         r.assertEqualDataBoundBeans(s, stepTester.configRoundTrip(s));
-        snippetizerTester.assertRoundTrip(s, "library changelog: false, identifier: 'foo@master', retriever: legacySCM([$class: 'GitSCM', branches: [[name: '${library.foo.version}']], doGenerateSubmoduleConfigurations: false, extensions: [], submoduleCfg: [], userRemoteConfigs: [[url: 'https://nowhere.net/']]])");
+        snippetizerTester.assertRoundTrip(s, "library changelog: false, identifier: 'foo@master', retriever: legacySCM([$class: 'GitSCM', branches: [[name: '${library.foo.version}']], extensions: [], userRemoteConfigs: [[url: 'https://nowhere.net/']]])");
     }
 
     @Test public void vars() throws Exception {


### PR DESCRIPTION
## Fix the git snippet test for git plugin 4.6.0

The git snippet test will fail when the git plugin dependency is updated to git plugin 4.6.0.  This pull request shows one way to fix the test.

### Require Jenkins 2.222.4 or newer

Recent releases of the git plugin require 2.222.4 as their minimum Jenkins version.  Jenkins 2.235.1 is the version recommended by https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/

### Adapt snippet tests for git plugin 4.6.0

[Git plugin 4.6.0](https://github.com/jenkinsci/git-plugin/releases/tag/git-4.6.0) removed the undocumented submodule configurator experiment so that the pipeline syntax snippet generator no longer includes `doGenerateSubmoduleConfigurations` or `submoduleCfg`.  They are accepted as arguments but any values assigned to them are ignored.

The test could have been adapted to run with both older and newer versions of the git plugin, but it seems simpler and easier to show the current behavior.
