### PR TITLE
Expose LibrariesAction and LibraryRecord to Jenkins' REST API

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibrariesAction.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibrariesAction.java
@@ -33,11 +33,14 @@ import hudson.model.TaskListener;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
 /**
  * A run action recording libraries used in a given build.
  */
-class LibrariesAction extends InvisibleAction {
+@ExportedBean
+public class LibrariesAction extends InvisibleAction {
 
     private final List<LibraryRecord> libraries;
 
@@ -48,6 +51,7 @@ class LibrariesAction extends InvisibleAction {
     /**
      * A list of libraries in use.
      */
+    @Exported
     public List<LibraryRecord> getLibraries() {
         return Collections.unmodifiableList(libraries);
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRecord.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryRecord.java
@@ -24,13 +24,17 @@
 
 package org.jenkinsci.plugins.workflow.libs;
 
+import java.util.Collections;
 import java.util.Set;
 import java.util.TreeSet;
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
 
 /**
  * Record of a library being used in a particular build.
  */
-final class LibraryRecord {
+@ExportedBean
+public final class LibraryRecord {
 
     final String name;
     final String version;
@@ -43,6 +47,31 @@ final class LibraryRecord {
         this.version = version;
         this.trusted = trusted;
         this.changelog = changelog;
+    }
+
+    @Exported
+    public String getName() {
+        return name;
+    }
+
+    @Exported
+    public String getVersion() {
+        return version;
+    }
+
+    @Exported
+    public Set<String> getVariables() {
+        return Collections.unmodifiableSet(variables);
+    }
+
+    @Exported
+    public boolean isTrusted() {
+        return trusted;
+    }
+
+    @Exported
+    public boolean isChangelog() {
+        return changelog;
     }
 
     @Override public String toString() {


### PR DESCRIPTION
This PR exposes data about shared libraries used by a build through the Jenkins REST API. The information was already being stored in `LibrariesAction` and `LibraryRecord`, it was just not exposed to the API. Somewhat similar to #102, which I also think is a good idea. 

I did not add any tests in this PR that use the API, but I could do so if desired.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
