### PR TITLE
[JENKINS-65612] Support for immediately cleaning `@libs` workspaces

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/SCMRetriever.java
@@ -45,6 +45,7 @@ import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.DoNotUse;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 /**
  * Uses legacy {@link SCM} to check out sources based on variable interpolation.
@@ -52,6 +53,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class SCMRetriever extends LibraryRetriever {
 
     private final SCM scm;
+    private boolean cleanWorkspace;
 
     @DataBoundConstructor public SCMRetriever(SCM scm) {
         this.scm = scm;
@@ -61,12 +63,21 @@ public class SCMRetriever extends LibraryRetriever {
         return scm;
     }
 
+    public boolean getCleanWorkspace() {
+        return cleanWorkspace;
+    }
+
+    @DataBoundSetter
+    public void setCleanWorkspace(boolean cleanWorkspace) {
+        this.cleanWorkspace = cleanWorkspace;
+    }
+
     @Override public void retrieve(String name, String version, boolean changelog, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
-        SCMSourceRetriever.doRetrieve(name, changelog, scm, target, run, listener);
+        SCMSourceRetriever.doRetrieve(name, changelog, cleanWorkspace, scm, target, run, listener);
     }
 
     @Override public void retrieve(String name, String version, FilePath target, Run<?, ?> run, TaskListener listener) throws Exception {
-        SCMSourceRetriever.doRetrieve(name, true, scm, target, run, listener);
+        SCMSourceRetriever.doRetrieve(name, true, cleanWorkspace, scm, target, run, listener);
     }
     
     @Override public FormValidation validateVersion(String name, String version, Item context) {

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMRetriever/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMRetriever/config.jelly
@@ -26,4 +26,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:descriptorRadioList varName="scm" instance="${instance.scm}" descriptors="${descriptor.SCMDescriptors}" title="${%Source Code Management}"/>
+    <f:entry field="cleanWorkspace" title="${%Clean workspace after retrieval}">
+        <f:checkbox/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMRetriever/help-cleanWorkspace.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMRetriever/help-cleanWorkspace.html
@@ -1,0 +1,3 @@
+<div>
+  <p>If checked, the contents of the workspace used to retrieve the shared library will be removed after the shared library has been retrieved.</p>
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever/config.jelly
@@ -26,4 +26,7 @@ THE SOFTWARE.
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:descriptorRadioList varName="scm" instance="${instance.scm}" descriptors="${descriptor.SCMDescriptors}" title="${%Source Code Management}"/>
+    <f:entry field="cleanWorkspace" title="${%Clean workspace after retrieval}">
+        <f:checkbox/>
+    </f:entry>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever/help-cleanWorkspace.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/SCMSourceRetriever/help-cleanWorkspace.html
@@ -1,0 +1,3 @@
+<div>
+  <p>If checked, the contents of the workspace used to retrieve the shared library will be removed after the shared library has been retrieved.</p>
+</div>


### PR DESCRIPTION
See [JENKINS-65612](https://issues.jenkins.io/browse/JENKINS-65612). `SCMRetriever` and `SCMSourceRetriever` create a `@libs` workspace for retrieving the shared library before copying it into the build directory. While old build directories are eventually discarded based on the global build discarder configuration, these `@libs` workspaces tend to stick around for a long time and eventually need to be removed. It would be nice if a flag could be set on `SCMRetriever` and `SCMSourceRetriever` to clean these `@libs` workspaces immediately after we are done with them.