### PR TITLE
Use Subversion version specified in BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,6 @@
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.222.4</jenkins.version>
         <java.level>8</java.level>
-        <subversion-plugin.version>2.14.0</subversion-plugin.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
     <dependencyManagement>
@@ -74,7 +73,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.222.x</artifactId>
-                <version>831.v9814430e6383</version>
+                <version>872.v03c18fa35487</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -191,13 +190,11 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
-            <version>${subversion-plugin.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>subversion</artifactId>
-            <version>${subversion-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
Needed to adapt to the Commons Digester removal in PCT tests for 2.297 and later.