### PR TITLE
[JENKINS-66045] Fix NPE in cache exclusions

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
@@ -12,6 +12,7 @@ import org.kohsuke.stapler.QueryParameter;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public final class LibraryCachingConfiguration extends AbstractDescribableImpl<LibraryCachingConfiguration> {
@@ -45,6 +46,9 @@ public final class LibraryCachingConfiguration extends AbstractDescribableImpl<L
     }
 
     private List<String> getExcludedVersions() {
+        if (excludedVersionsStr == null) {
+            return Collections.emptyList();
+        }
         return Arrays.asList(excludedVersionsStr.split(VERSIONS_SEPARATOR));
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfigurationTest.java
@@ -1,0 +1,120 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2021 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.libs;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class LibraryCachingConfigurationTest {
+    private LibraryCachingConfiguration nullVersionConfig;
+    private LibraryCachingConfiguration oneVersionConfig;
+    private LibraryCachingConfiguration multiVersionConfig;
+
+    private static int REFRESH_TIME_MINUTES = 23;
+    private static int NO_REFRESH_TIME_MINUTES = 0;
+
+    private static String NULL_EXCLUDED_VERSION = null;
+    private static String ONE_EXCLUDED_VERSION = "branch-1";
+
+    private static String MULTIPLE_EXCLUDED_VERSIONS_1 = "main";
+    private static String MULTIPLE_EXCLUDED_VERSIONS_2 = "branch-2";
+    private static String MULTIPLE_EXCLUDED_VERSIONS_3 = "branch-3";
+
+    private static String MULTIPLE_EXCLUDED_VERSIONS =
+        MULTIPLE_EXCLUDED_VERSIONS_1 + " " +
+        MULTIPLE_EXCLUDED_VERSIONS_2 + " " +
+        MULTIPLE_EXCLUDED_VERSIONS_3;
+
+    private static String NEVER_EXCLUDED_VERSION = "never-excluded-version";
+
+    @Before
+    public void createCachingConfiguration() {
+        nullVersionConfig = new LibraryCachingConfiguration(REFRESH_TIME_MINUTES, NULL_EXCLUDED_VERSION);
+        oneVersionConfig = new LibraryCachingConfiguration(NO_REFRESH_TIME_MINUTES, ONE_EXCLUDED_VERSION);
+        multiVersionConfig = new LibraryCachingConfiguration(REFRESH_TIME_MINUTES, MULTIPLE_EXCLUDED_VERSIONS);
+    }
+
+    @Issue("JENKINS-66045") // NPE getting excluded versions
+    @Test
+    public void npeGetExcludedVersions() {
+        assertFalse(nullVersionConfig.isExcluded(NEVER_EXCLUDED_VERSION));
+    }
+
+    @Test
+    public void getRefreshTimeMinutes() {
+        assertThat(nullVersionConfig.getRefreshTimeMinutes(), is(REFRESH_TIME_MINUTES));
+        assertThat(oneVersionConfig.getRefreshTimeMinutes(), is(NO_REFRESH_TIME_MINUTES));
+    }
+
+    @Test
+    public void getRefreshTimeMilliseconds() {
+        assertThat(nullVersionConfig.getRefreshTimeMilliseconds(), is(60 * 1000L * REFRESH_TIME_MINUTES));
+        assertThat(oneVersionConfig.getRefreshTimeMilliseconds(), is(60 * 1000L * NO_REFRESH_TIME_MINUTES));
+    }
+
+    @Test
+    public void isRefreshEnabled() {
+        assertTrue(nullVersionConfig.isRefreshEnabled());
+        assertFalse(oneVersionConfig.isRefreshEnabled());
+    }
+
+    @Test
+    public void getExcludedVersionsStr() {
+        assertThat(nullVersionConfig.getExcludedVersionsStr(), is(NULL_EXCLUDED_VERSION));
+        assertThat(oneVersionConfig.getExcludedVersionsStr(), is(ONE_EXCLUDED_VERSION));
+        assertThat(multiVersionConfig.getExcludedVersionsStr(), is(MULTIPLE_EXCLUDED_VERSIONS));
+    }
+
+    @Test
+    public void isExcluded() {
+        assertFalse(nullVersionConfig.isExcluded(NULL_EXCLUDED_VERSION));
+        assertFalse(nullVersionConfig.isExcluded(""));
+
+        assertTrue(oneVersionConfig.isExcluded(ONE_EXCLUDED_VERSION));
+
+        assertTrue(multiVersionConfig.isExcluded(MULTIPLE_EXCLUDED_VERSIONS_1));
+        assertTrue(multiVersionConfig.isExcluded(MULTIPLE_EXCLUDED_VERSIONS_2));
+        assertTrue(multiVersionConfig.isExcluded(MULTIPLE_EXCLUDED_VERSIONS_3));
+
+        assertFalse(nullVersionConfig.isExcluded(NEVER_EXCLUDED_VERSION));
+        assertFalse(oneVersionConfig.isExcluded(NEVER_EXCLUDED_VERSION));
+        assertFalse(multiVersionConfig.isExcluded(NEVER_EXCLUDED_VERSION));
+
+        assertFalse(nullVersionConfig.isExcluded(""));
+        assertFalse(oneVersionConfig.isExcluded(""));
+        assertFalse(multiVersionConfig.isExcluded(""));
+
+        assertFalse(nullVersionConfig.isExcluded(null));
+        assertFalse(oneVersionConfig.isExcluded(null));
+        assertFalse(multiVersionConfig.isExcluded(null));
+    }
+
+}


### PR DESCRIPTION
## Fix NPE in cache exclusions check

- [JENKINS-66045](https://issues.jenkins.io/browse/JENKINS-66045) test for NPE if exclusions are empty
- [JENKINS-66045](https://issues.jenkins.io/browse/JENKINS-66045) Fix NPE checking version exclusion
