### PR TITLE
Allow explicit selection of default library tag.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryConfiguration.java
@@ -140,7 +140,7 @@ public class LibraryConfiguration extends AbstractDescribableImpl<LibraryConfigu
     }
 
     @Nonnull String defaultedVersion(@CheckForNull String version) throws AbortException {
-        if (version == null) {
+        if ( (version == null) || (version.equals(defaultVersion)) ) {
             if (defaultVersion == null) {
                 throw new AbortException("No version specified for library " + name);
             } else {


### PR DESCRIPTION
If developer manually specifies the default version of a library where overriding the default version is not allowed, this should allow the checkout to proceed normally.

https://issues.jenkins.io/browse/JENKINS-66682

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [] Link to relevant pull requests, esp. upstream and downstream changes
- [] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
