### PR TITLE
No need to override `reuseForks`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.30</version>
+        <version>4.31</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -209,15 +209,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <reuseForks>false</reuseForks> <!-- TODO reuse seems to cause problems in LibraryMemoryTest -->
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>


### PR DESCRIPTION
As of https://github.com/jenkinsci/plugin-pom/pull/453.
