### PR TITLE
Fix recent security fixes if JENKINS_HOME is a symlink and update tests for compatibility with Windows and Git plugin 4.10.3

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
@@ -256,7 +256,7 @@ import org.jenkinsci.plugins.workflow.flow.FlowCopier;
                 for (LibraryRecord library : action.getLibraries()) {
                     FilePath libResources = libs.child(library.getDirectoryName() + "/resources/");
                     FilePath f = libResources.child(name);
-                    if (!new File(f.getRemote()).getCanonicalFile().toPath().startsWith(libResources.absolutize().getRemote())) {
+                    if (!new File(f.getRemote()).getCanonicalFile().toPath().startsWith(new File(libResources.getRemote()).getCanonicalPath())) {
                         throw new AbortException(name + " references a file that is not contained within the library: " + library.name);
                     } else if (f.exists()) {
                         resources.put(library.name, readResource(f, encoding));

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/ResourceStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/ResourceStepTest.java
@@ -189,6 +189,7 @@ public class ResourceStepTest {
 
     @Issue("SECURITY-2479")
     @Test public void symlinksInLibraryResourcesAreNotAllowedToEscapeWorkspaceContext() throws Exception {
+        assumeFalse(Functions.isWindows()); // On Windows, the symlink is treated as a regular file, so there is no vulnerability, but the behavior is different.
         sampleRepo.init();
         sampleRepo.write("src/Stuff.groovy", "class Stuff {static def contents(script) {script.libraryResource 'master.key'}}");
         Path resourcesDir = Paths.get(sampleRepo.getRoot().getPath(), "resources");

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetrieverTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/SCMSourceRetrieverTest.java
@@ -39,6 +39,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -425,7 +426,10 @@ public class SCMSourceRetrieverTest {
         FileUtils.copyDirectory(new File(sampleRepo.getRoot(), ".git"), gitDirInSvnRepo);
         String jenkinsRootDir = r.jenkins.getRootDir().toString();
         // Add a Git post-checkout hook to the .git folder in the SVN repo.
-        Files.write(gitDirInSvnRepo.toPath().resolve("hooks/post-checkout"), ("#!/bin/sh\ntouch '" + jenkinsRootDir + "/hook-executed'\n").getBytes(StandardCharsets.UTF_8));
+        Path postCheckoutHook = gitDirInSvnRepo.toPath().resolve("hooks/post-checkout");
+        // Always create hooks directory for compatibility with https://github.com/jenkinsci/git-plugin/pull/1207.
+        Files.createDirectories(postCheckoutHook.getParent());
+        Files.write(postCheckoutHook, ("#!/bin/sh\ntouch '" + jenkinsRootDir + "/hook-executed'\n").getBytes(StandardCharsets.UTF_8));
         sampleRepoSvn.svnkit("add", sampleRepoSvn.wc() + "/vars");
         sampleRepoSvn.svnkit("add", sampleRepoSvn.wc() + "/.git");
         sampleRepoSvn.svnkit("propset", "svn:executable", "ON", sampleRepoSvn.wc() + "/.git/hooks/post-checkout");


### PR DESCRIPTION
The tests for security fixes for https://www.jenkins.io/security/advisory/2022-02-15/ fail against recent version of Git plugin due to https://github.com/jenkinsci/git-plugin/pull/1207, and also fail when running on Windows due to a difference in the behavior.

The fix itself also did not allow `JENKINS_HOME` to be a symlink, because it compared a canonical path to an absolute path.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
