### PR TITLE
convert library cache exclude to substring search

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
@@ -53,15 +53,14 @@ public final class LibraryCachingConfiguration extends AbstractDescribableImpl<L
     }
 
     public Boolean isExcluded(String version) {
-        return getExcludedVersions().contains(version);
-        // try{
-        //     for (String it : getExcludedVersions()){
-        //         if ((version.contains(it)) && (it != "")){
-        //             return true;
-        //         }
-        //     }
-        // }finally{}
-        // return false;
+        if(version != null){
+            for (String it : getExcludedVersions()){
+                if ((version.contains(it)) && (it != "")){
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     @Override public String toString() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
@@ -53,7 +53,12 @@ public final class LibraryCachingConfiguration extends AbstractDescribableImpl<L
     }
 
     public Boolean isExcluded(String version) {
-        return getExcludedVersions().contains(version);
+        for (String it : getExcludedVersions()){
+            if (version.contains(it)){
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override public String toString() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
@@ -62,7 +62,7 @@ public final class LibraryCachingConfiguration extends AbstractDescribableImpl<L
             // confirm that the excluded versions aren't null or empty
             // and if the version contains the exclusion thus it can be
             // anywhere in the string.
-            if (StringUtils.contains(it, version)) {
+            if (StringUtils.isNotBlank(it) && version.contains(it)){
                 return true;
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
@@ -53,12 +53,14 @@ public final class LibraryCachingConfiguration extends AbstractDescribableImpl<L
     }
 
     public Boolean isExcluded(String version) {
+        boolean isFound = false;
         for (String it : getExcludedVersions()){
             if (version.contains(it)){
-                return true;
+                isFound = true;
+                break;
             }
         }
-        return false;
+        return isFound;
     }
 
     @Override public String toString() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
@@ -61,7 +61,7 @@ public final class LibraryCachingConfiguration extends AbstractDescribableImpl<L
         for (String it : getExcludedVersions()) {
             // confirm that the excluded versions aren't null or empty
             // and if the version contains the exclusion thus it can be
-            // anywhere in the string.
+            // anywhere in the string .
             if (StringUtils.contains(version, it)){
                 return true;
             }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
@@ -53,12 +53,11 @@ public final class LibraryCachingConfiguration extends AbstractDescribableImpl<L
     }
 
     public Boolean isExcluded(String version) {
-        if(version == null){
-            return false;
-        }
-        for (String it : getExcludedVersions()){
-            if (version.contains(it)){
-                return true;
+        if(!version.equals(null)){
+            for (String it : getExcludedVersions()){
+                if (version.contains(it)){
+                    return true;
+                }
             }
         }
         return false;

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
@@ -53,11 +53,12 @@ public final class LibraryCachingConfiguration extends AbstractDescribableImpl<L
     }
 
     public Boolean isExcluded(String version) {
-        if(version != null){
-            for (String it : getExcludedVersions()){
-                if ((version.contains(it)) && (it != "")){
-                    return true;
-                }
+        if(version == null){
+            return false;
+        }
+        for (String it : getExcludedVersions()){
+            if (version.contains(it)){
+                return true;
             }
         }
         return false;

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
@@ -53,14 +53,12 @@ public final class LibraryCachingConfiguration extends AbstractDescribableImpl<L
     }
 
     public Boolean isExcluded(String version) {
-        boolean isFound = false;
         for (String it : getExcludedVersions()){
-            if (version.contains(it)){
-                isFound = true;
-                break;
+            if ((version.contains(it)) && (version != "") && (it != "")){
+                return true;
             }
         }
-        return isFound;
+        return false;
     }
 
     @Override public String toString() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
@@ -14,6 +14,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.apache.commons.lang.StringUtils;
 
 public final class LibraryCachingConfiguration extends AbstractDescribableImpl<LibraryCachingConfiguration> {
     private int refreshTimeMinutes;
@@ -53,11 +54,16 @@ public final class LibraryCachingConfiguration extends AbstractDescribableImpl<L
     }
 
     public Boolean isExcluded(String version) {
-        if(!version.equals(null)){
-            for (String it : getExcludedVersions()){
-                if (version.contains(it) && !it.equals("") && !it.equals(null)){
-                    return true;
-                }
+        // exit early if the version passed in is null or empty
+        if (StringUtils.isBlank(version)) {
+            return false;
+        }
+        for (String it : getExcludedVersions()) {
+            // confirm that the excluded versions aren't null or empty
+            // and if the version contains the exclusion thus it can be
+            // anywhere in the string.
+            if (StringUtils.isNotBlank(it) && version.contains(it)){
+                return true;
             }
         }
         return false;

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
@@ -61,8 +61,8 @@ public final class LibraryCachingConfiguration extends AbstractDescribableImpl<L
         for (String it : getExcludedVersions()) {
             // confirm that the excluded versions aren't null or empty
             // and if the version contains the exclusion thus it can be
-            // anywhere in the string .
-            if (StringUtils.contains(version, it)){
+            // anywhere in the string.
+            if (StringUtils.isNotBlank(it) && version.contains(it)){
                 return true;
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
@@ -53,13 +53,13 @@ public final class LibraryCachingConfiguration extends AbstractDescribableImpl<L
     }
 
     public Boolean isExcluded(String version) {
-        if(version != ""){
+        try{
             for (String it : getExcludedVersions()){
                 if ((version.contains(it)) && (it != "")){
                     return true;
                 }
             }
-        }
+        }finally{}
         return false;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
@@ -62,7 +62,7 @@ public final class LibraryCachingConfiguration extends AbstractDescribableImpl<L
             // confirm that the excluded versions aren't null or empty
             // and if the version contains the exclusion thus it can be
             // anywhere in the string.
-            if (StringUtils.isNotBlank(it) && version.contains(it)){
+            if (StringUtils.contains(it, version)) {
                 return true;
             }
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
@@ -53,14 +53,15 @@ public final class LibraryCachingConfiguration extends AbstractDescribableImpl<L
     }
 
     public Boolean isExcluded(String version) {
-        try{
-            for (String it : getExcludedVersions()){
-                if ((version.contains(it)) && (it != "")){
-                    return true;
-                }
-            }
-        }finally{}
-        return false;
+        return getExcludedVersions().contains(version);
+        // try{
+        //     for (String it : getExcludedVersions()){
+        //         if ((version.contains(it)) && (it != "")){
+        //             return true;
+        //         }
+        //     }
+        // }finally{}
+        // return false;
     }
 
     @Override public String toString() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
@@ -55,7 +55,7 @@ public final class LibraryCachingConfiguration extends AbstractDescribableImpl<L
     public Boolean isExcluded(String version) {
         if(!version.equals(null)){
             for (String it : getExcludedVersions()){
-                if (version.contains(it)){
+                if (version.contains(it) && !it.equals("") && !it.equals(null)){
                     return true;
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
@@ -53,9 +53,11 @@ public final class LibraryCachingConfiguration extends AbstractDescribableImpl<L
     }
 
     public Boolean isExcluded(String version) {
-        for (String it : getExcludedVersions()){
-            if ((version.contains(it)) && (version != "") && (it != "")){
-                return true;
+        if(version != ""){
+            for (String it : getExcludedVersions()){
+                if ((version.contains(it)) && (it != "")){
+                    return true;
+                }
             }
         }
         return false;

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration.java
@@ -62,7 +62,7 @@ public final class LibraryCachingConfiguration extends AbstractDescribableImpl<L
             // confirm that the excluded versions aren't null or empty
             // and if the version contains the exclusion thus it can be
             // anywhere in the string.
-            if (StringUtils.isNotBlank(it) && version.contains(it)){
+            if (StringUtils.contains(version, it)){
                 return true;
             }
         }

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration/help-excludedVersionsStr.html
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration/help-excludedVersionsStr.html
@@ -1,3 +1,3 @@
 <div>
-    Space separated list of versions excluded from caching. Ex: "master release10 release9"
+    Space separated list of versions to exclude from caching via substring search using .contains() method. Ex: "release/ master release10 release9".
 </div>

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfigurationTest.java
@@ -49,8 +49,8 @@ public class LibraryCachingConfigurationTest {
     private static String MULTIPLE_EXCLUDED_VERSIONS_2 = "branch-2";
     private static String MULTIPLE_EXCLUDED_VERSIONS_3 = "branch-3";
 
-    private static String SUBSTRING_EXCLUDED_VERSIONS_1 = "feature";
-    private static String SUBSTRING_EXCLUDED_VERSIONS_2 = "other-substring";
+    private static String SUBSTRING_EXCLUDED_VERSIONS_1 = "feature/test-substring-exclude";
+    private static String SUBSTRING_EXCLUDED_VERSIONS_2 = "test-other-substring-exclude";
 
     private static String MULTIPLE_EXCLUDED_VERSIONS =
         MULTIPLE_EXCLUDED_VERSIONS_1 + " " +
@@ -58,7 +58,7 @@ public class LibraryCachingConfigurationTest {
         MULTIPLE_EXCLUDED_VERSIONS_3;
 
     private static String SUBSTRING_EXCLUDED_VERSIONS =
-        "feature/test-substring-exclude test-other-substring-exclude";
+        "feature/ other-substring";
 
     private static String NEVER_EXCLUDED_VERSION = "never-excluded-version";
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfigurationTest.java
@@ -37,6 +37,7 @@ public class LibraryCachingConfigurationTest {
     private LibraryCachingConfiguration nullVersionConfig;
     private LibraryCachingConfiguration oneVersionConfig;
     private LibraryCachingConfiguration multiVersionConfig;
+    private LibraryCachingConfiguration substringVersionConfig;
 
     private static int REFRESH_TIME_MINUTES = 23;
     private static int NO_REFRESH_TIME_MINUTES = 0;
@@ -48,10 +49,16 @@ public class LibraryCachingConfigurationTest {
     private static String MULTIPLE_EXCLUDED_VERSIONS_2 = "branch-2";
     private static String MULTIPLE_EXCLUDED_VERSIONS_3 = "branch-3";
 
+    private static String SUBSTRING_EXCLUDED_VERSIONS_1 = "feature/";
+    private static String SUBSTRING_EXCLUDED_VERSIONS_2 = "other-substring";
+
     private static String MULTIPLE_EXCLUDED_VERSIONS =
         MULTIPLE_EXCLUDED_VERSIONS_1 + " " +
         MULTIPLE_EXCLUDED_VERSIONS_2 + " " +
         MULTIPLE_EXCLUDED_VERSIONS_3;
+
+    private static String SUBSTRING_EXCLUDED_VERSIONS =
+        "feature/test-substring-exclude test-other-substring-exclude";
 
     private static String NEVER_EXCLUDED_VERSION = "never-excluded-version";
 
@@ -60,6 +67,7 @@ public class LibraryCachingConfigurationTest {
         nullVersionConfig = new LibraryCachingConfiguration(REFRESH_TIME_MINUTES, NULL_EXCLUDED_VERSION);
         oneVersionConfig = new LibraryCachingConfiguration(NO_REFRESH_TIME_MINUTES, ONE_EXCLUDED_VERSION);
         multiVersionConfig = new LibraryCachingConfiguration(REFRESH_TIME_MINUTES, MULTIPLE_EXCLUDED_VERSIONS);
+        substringVersionConfig = new LibraryCachingConfiguration(REFRESH_TIME_MINUTES, SUBSTRING_EXCLUDED_VERSIONS);
     }
 
     @Issue("JENKINS-66045") // NPE getting excluded versions
@@ -91,6 +99,7 @@ public class LibraryCachingConfigurationTest {
         assertThat(nullVersionConfig.getExcludedVersionsStr(), is(NULL_EXCLUDED_VERSION));
         assertThat(oneVersionConfig.getExcludedVersionsStr(), is(ONE_EXCLUDED_VERSION));
         assertThat(multiVersionConfig.getExcludedVersionsStr(), is(MULTIPLE_EXCLUDED_VERSIONS));
+        assertThat(substringVersionConfig.getExcludedVersionsStr(), is(SUBSTRING_EXCLUDED_VERSIONS));
     }
 
     @Test
@@ -103,6 +112,9 @@ public class LibraryCachingConfigurationTest {
         assertTrue(multiVersionConfig.isExcluded(MULTIPLE_EXCLUDED_VERSIONS_1));
         assertTrue(multiVersionConfig.isExcluded(MULTIPLE_EXCLUDED_VERSIONS_2));
         assertTrue(multiVersionConfig.isExcluded(MULTIPLE_EXCLUDED_VERSIONS_3));
+
+        assertTrue(substringVersionConfig.isExcluded(SUBSTRING_EXCLUDED_VERSIONS_1));
+        assertTrue(substringVersionConfig.isExcluded(SUBSTRING_EXCLUDED_VERSIONS_2));
 
         assertFalse(nullVersionConfig.isExcluded(NEVER_EXCLUDED_VERSION));
         assertFalse(oneVersionConfig.isExcluded(NEVER_EXCLUDED_VERSION));

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfigurationTest.java
@@ -49,7 +49,7 @@ public class LibraryCachingConfigurationTest {
     private static String MULTIPLE_EXCLUDED_VERSIONS_2 = "branch-2";
     private static String MULTIPLE_EXCLUDED_VERSIONS_3 = "branch-3";
 
-    private static String SUBSTRING_EXCLUDED_VERSIONS_1 = "feature/";
+    private static String SUBSTRING_EXCLUDED_VERSIONS_1 = "feature";
     private static String SUBSTRING_EXCLUDED_VERSIONS_2 = "other-substring";
 
     private static String MULTIPLE_EXCLUDED_VERSIONS =

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfigurationTest.java
@@ -123,10 +123,12 @@ public class LibraryCachingConfigurationTest {
         assertFalse(nullVersionConfig.isExcluded(""));
         assertFalse(oneVersionConfig.isExcluded(""));
         assertFalse(multiVersionConfig.isExcluded(""));
+        assertFalse(substringVersionConfig.isExcluded(""));
 
         assertFalse(nullVersionConfig.isExcluded(null));
         assertFalse(oneVersionConfig.isExcluded(null));
         assertFalse(multiVersionConfig.isExcluded(null));
+        assertFalse(substringVersionConfig.isExcluded(null));
     }
 
 }


### PR DESCRIPTION
Converting the library cache code to be a substring search vice explicit string.  This enables blanket exemptions for things like feature branches without breaking current functionality. This is required to enable caching for branches like master and exclude others without having to know the full name as a feature branch would be dynamic.

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

All tests run and caching works as expected with change.  Unfortunately I cannot upload screenshots due to work requirements. I validated all build tests worked as well.