### PR TITLE
Fix library cache deletion after SECURITY-2586

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryAdder.java
@@ -190,7 +190,6 @@ import org.jenkinsci.plugins.workflow.flow.FlowCopier;
 
             if(versionCacheDir.exists()) {
                 listener.getLogger().println("Library " + name + "@" + version + " is cached. Copying from home.");
-                lastReadFile.touch(System.currentTimeMillis());
             } else {
                 listener.getLogger().println("Caching library " + name + "@" + version);
                 versionCacheDir.mkdirs();
@@ -198,6 +197,8 @@ import org.jenkinsci.plugins.workflow.flow.FlowCopier;
                 retriever.retrieve(name, version, changelog, versionCacheDir, run, listener);
                 retrieveLockFile.delete();
             }
+            lastReadFile.touch(System.currentTimeMillis());
+            versionCacheDir.withSuffix("-name.txt").write(name, "UTF-8");
             versionCacheDir.copyRecursiveTo(libDir);
         } else {
             retriever.retrieve(name, version, changelog, libDir, run, listener);

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingCleanup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingCleanup.java
@@ -8,29 +8,47 @@ import hudson.model.TaskListener;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 
+import jenkins.util.SystemProperties;
+
 @Extension public class LibraryCachingCleanup extends AsyncPeriodicWork {
-    private final Long recurrencePeriod;
-    private final Long unreadCacheClearTime;
+    public static /* non-final for script console */ int EXPIRE_AFTER_READ_DAYS =
+            SystemProperties.getInteger(LibraryCachingCleanup.class.getName() + ".CACHE_EXPIRY_DAYS", 7);
 
     public LibraryCachingCleanup() {
         super("LibraryCachingCleanup");
-        recurrencePeriod = Long.getLong("jenkins.workflow-libs.cacheCleanupPeriodDays", TimeUnit.DAYS.toMillis(7));
-        unreadCacheClearTime = Long.getLong("jenkins.workflow-libs.unreadCacheClearDays", TimeUnit.DAYS.toMillis(7));
     }
 
     @Override public long getRecurrencePeriod() {
-        return recurrencePeriod;
+        return TimeUnit.HOURS.toMillis(12);
     }
 
     @Override protected void execute(TaskListener listener) throws IOException, InterruptedException {
         FilePath globalCacheDir = LibraryCachingConfiguration.getGlobalLibrariesCacheDir();
-        for (FilePath library: globalCacheDir.list()) {
-            for (FilePath version: library.list()) {
-                final FilePath lastReadFile = new FilePath(version, LibraryCachingConfiguration.LAST_READ_FILE);
-                if (lastReadFile.exists() && (lastReadFile.lastModified() + unreadCacheClearTime) < System.currentTimeMillis()) {
-                    version.deleteRecursive();
+        for (FilePath library : globalCacheDir.list()) {
+            if (!removeIfOldCacheDirectory(library, TimeUnit.DAYS.toMillis(EXPIRE_AFTER_READ_DAYS))) {
+                // Prior to SECURITY-2586 security fixes, library caches had a two-level directory structure.
+                // These caches will never be used again, so we delete any that we find.
+                for (FilePath version: library.list()) {
+                    removeIfOldCacheDirectory(version, 0);
                 }
             }
         }
+    }
+
+    /**
+     * Delete cache directories for the given library if they are outdated.
+     * @return true if specified directory is a cache directory, regardless of whether it was outdated. Used to detect
+     * whether the cache was created before or after the fix for SECURITY-2586.
+     */
+    private boolean removeIfOldCacheDirectory(FilePath library, long maxDurationMillis) throws IOException, InterruptedException {
+        final FilePath lastReadFile = new FilePath(library, LibraryCachingConfiguration.LAST_READ_FILE);
+        if (lastReadFile.exists()) {
+            if ((System.currentTimeMillis() - lastReadFile.lastModified()) > maxDurationMillis) {
+                library.deleteRecursive();
+                library.withSuffix("-name.txt").delete(); // Harmless if this is a pre-SECURITY-2586 cache directory.
+            }
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingCleanup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingCleanup.java
@@ -12,7 +12,7 @@ import jenkins.util.SystemProperties;
 
 @Extension public class LibraryCachingCleanup extends AsyncPeriodicWork {
     public static /* non-final for script console */ int EXPIRE_AFTER_READ_DAYS =
-            SystemProperties.getInteger(LibraryCachingCleanup.class.getName() + ".CACHE_EXPIRY_DAYS", 7);
+            SystemProperties.getInteger(LibraryCachingCleanup.class.getName() + ".EXPIRE_AFTER_READ_DAYS", 7);
 
     public LibraryCachingCleanup() {
         super("LibraryCachingCleanup");

--- a/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingCleanup.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingCleanup.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.workflow.libs;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.model.AsyncPeriodicWork;
@@ -11,7 +12,8 @@ import java.util.concurrent.TimeUnit;
 import jenkins.util.SystemProperties;
 
 @Extension public class LibraryCachingCleanup extends AsyncPeriodicWork {
-    public static /* non-final for script console */ int EXPIRE_AFTER_READ_DAYS =
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "non-final for script console access")
+    public static int EXPIRE_AFTER_READ_DAYS =
             SystemProperties.getInteger(LibraryCachingCleanup.class.getName() + ".EXPIRE_AFTER_READ_DAYS", 7);
 
     public LibraryCachingCleanup() {
@@ -40,10 +42,10 @@ import jenkins.util.SystemProperties;
      * @return true if specified directory is a cache directory, regardless of whether it was outdated. Used to detect
      * whether the cache was created before or after the fix for SECURITY-2586.
      */
-    private boolean removeIfOldCacheDirectory(FilePath library, long maxDurationMillis) throws IOException, InterruptedException {
+    private boolean removeIfOldCacheDirectory(FilePath library, long maxDurationSinceLastReadMillis) throws IOException, InterruptedException {
         final FilePath lastReadFile = new FilePath(library, LibraryCachingConfiguration.LAST_READ_FILE);
         if (lastReadFile.exists()) {
-            if ((System.currentTimeMillis() - lastReadFile.lastModified()) > maxDurationMillis) {
+            if ((System.currentTimeMillis() - lastReadFile.lastModified()) > maxDurationSinceLastReadMillis) {
                 library.deleteRecursive();
                 library.withSuffix("-name.txt").delete(); // Harmless if this is a pre-SECURITY-2586 cache directory.
             }

--- a/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfiguration/config.jelly
@@ -31,5 +31,7 @@ THE SOFTWARE.
     <f:entry title="${%Versions to exclude}" field="excludedVersionsStr">
         <f:textbox />
     </f:entry>
-    <f:validateButton title="${%Clear cache}" progress="${%Clearing...}" method="clearCache" with="name" />
+    <j:if test="${h.hasPermission(app.ADMINISTER)}">
+        <f:validateButton title="${%Clear cache}" progress="${%Clearing...}" method="clearCache" with="name" />
+    </j:if>
 </j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingCleanupTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingCleanupTest.java
@@ -1,0 +1,93 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2022 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.workflow.libs;
+
+import hudson.ExtensionList;
+import hudson.FilePath;
+import hudson.util.StreamTaskListener;
+import java.io.File;
+import java.time.ZonedDateTime;
+import jenkins.plugins.git.GitSCMSource;
+import jenkins.plugins.git.GitSampleRepoRule;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.io.FileMatchers.anExistingDirectory;
+import static org.hamcrest.io.FileMatchers.anExistingFile;
+
+public class LibraryCachingCleanupTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    @Rule
+    public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
+
+    @Test
+    public void smokes() throws Throwable {
+        sampleRepo.init();
+        sampleRepo.write("vars/foo.groovy", "def call() { echo 'foo' }");
+        sampleRepo.git("add", "vars");
+        sampleRepo.git("commit", "--message=init");
+        LibraryConfiguration config = new LibraryConfiguration("library",
+                new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)));
+        config.setDefaultVersion("master");
+        config.setImplicit(true);
+        config.setCachingConfiguration(new LibraryCachingConfiguration(30, null));
+        GlobalLibraries.get().getLibraries().add(config);
+        // Run build and check that cache gets created.
+        WorkflowJob p = r.createProject(WorkflowJob.class);
+        p.setDefinition(new CpsFlowDefinition("foo()", true));
+        WorkflowRun b = r.buildAndAssertSuccess(p);
+        LibrariesAction action = b.getAction(LibrariesAction.class);
+        LibraryRecord record = action.getLibraries().get(0);
+        FilePath cache = LibraryCachingConfiguration.getGlobalLibrariesCacheDir().child(record.getDirectoryName());
+        assertThat(new File(cache.getRemote()), anExistingDirectory());
+        // Run LibraryCachingCleanup and show that cache is not deleted.
+        ExtensionList.lookupSingleton(LibraryCachingCleanup.class).execute(StreamTaskListener.fromStderr());
+        assertThat(new File(cache.getRemote()), anExistingDirectory());
+        assertThat(new File(cache.withSuffix("-name.txt").getRemote()), anExistingFile());
+        // Run LibraryCachingCleanup after modifying LAST_READ_FILE to be an old date and and show that cache is deleted.
+        long oldMillis = ZonedDateTime.now().minusDays(LibraryCachingCleanup.EXPIRE_AFTER_READ_DAYS + 1).toInstant().toEpochMilli();
+        cache.child(LibraryCachingConfiguration.LAST_READ_FILE).touch(oldMillis);
+        ExtensionList.lookupSingleton(LibraryCachingCleanup.class).execute(StreamTaskListener.fromStderr());
+        assertThat(new File(cache.getRemote()), not(anExistingDirectory()));
+        assertThat(new File(cache.withSuffix("-name.txt").getRemote()), not(anExistingDirectory()));
+    }
+
+    @Test
+    public void preSecurity2586() throws Throwable {
+        FilePath cache = LibraryCachingConfiguration.getGlobalLibrariesCacheDir().child("name").child("version");
+        cache.mkdirs();
+        cache.child(LibraryCachingConfiguration.LAST_READ_FILE).touch(System.currentTimeMillis());
+        ExtensionList.lookupSingleton(LibraryCachingCleanup.class).execute(StreamTaskListener.fromStderr());
+        assertThat(new File(cache.getRemote()), not(anExistingDirectory()));
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingCleanupTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingCleanupTest.java
@@ -88,6 +88,7 @@ public class LibraryCachingCleanupTest {
         cache.child(LibraryCachingConfiguration.LAST_READ_FILE).touch(System.currentTimeMillis());
         ExtensionList.lookupSingleton(LibraryCachingCleanup.class).execute(StreamTaskListener.fromStderr());
         assertThat(new File(cache.getRemote()), not(anExistingDirectory()));
+        assertThat(new File(cache.getParent().getRemote()), not(anExistingDirectory()));
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfigurationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryCachingConfigurationTest.java
@@ -24,16 +24,34 @@
 
 package org.jenkinsci.plugins.workflow.libs;
 
+import hudson.ExtensionList;
+import hudson.FilePath;
+import java.io.File;
+import jenkins.plugins.git.GitSCMSource;
+import jenkins.plugins.git.GitSampleRepoRule;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.WithoutJenkins;
 
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
+import static org.hamcrest.io.FileMatchers.anExistingDirectory;
+import static org.hamcrest.io.FileMatchers.anExistingFile;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class LibraryCachingConfigurationTest {
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+    @Rule
+    public GitSampleRepoRule sampleRepo = new GitSampleRepoRule();
+
     private LibraryCachingConfiguration nullVersionConfig;
     private LibraryCachingConfiguration oneVersionConfig;
     private LibraryCachingConfiguration multiVersionConfig;
@@ -64,29 +82,34 @@ public class LibraryCachingConfigurationTest {
 
     @Issue("JENKINS-66045") // NPE getting excluded versions
     @Test
+    @WithoutJenkins
     public void npeGetExcludedVersions() {
         assertFalse(nullVersionConfig.isExcluded(NEVER_EXCLUDED_VERSION));
     }
 
     @Test
+    @WithoutJenkins
     public void getRefreshTimeMinutes() {
         assertThat(nullVersionConfig.getRefreshTimeMinutes(), is(REFRESH_TIME_MINUTES));
         assertThat(oneVersionConfig.getRefreshTimeMinutes(), is(NO_REFRESH_TIME_MINUTES));
     }
 
     @Test
+    @WithoutJenkins
     public void getRefreshTimeMilliseconds() {
         assertThat(nullVersionConfig.getRefreshTimeMilliseconds(), is(60 * 1000L * REFRESH_TIME_MINUTES));
         assertThat(oneVersionConfig.getRefreshTimeMilliseconds(), is(60 * 1000L * NO_REFRESH_TIME_MINUTES));
     }
 
     @Test
+    @WithoutJenkins
     public void isRefreshEnabled() {
         assertTrue(nullVersionConfig.isRefreshEnabled());
         assertFalse(oneVersionConfig.isRefreshEnabled());
     }
 
     @Test
+    @WithoutJenkins
     public void getExcludedVersionsStr() {
         assertThat(nullVersionConfig.getExcludedVersionsStr(), is(NULL_EXCLUDED_VERSION));
         assertThat(oneVersionConfig.getExcludedVersionsStr(), is(ONE_EXCLUDED_VERSION));
@@ -94,6 +117,7 @@ public class LibraryCachingConfigurationTest {
     }
 
     @Test
+    @WithoutJenkins
     public void isExcluded() {
         assertFalse(nullVersionConfig.isExcluded(NULL_EXCLUDED_VERSION));
         assertFalse(nullVersionConfig.isExcluded(""));
@@ -115,6 +139,33 @@ public class LibraryCachingConfigurationTest {
         assertFalse(nullVersionConfig.isExcluded(null));
         assertFalse(oneVersionConfig.isExcluded(null));
         assertFalse(multiVersionConfig.isExcluded(null));
+    }
+
+    @Test
+    public void clearCache() throws Exception {
+        sampleRepo.init();
+        sampleRepo.write("vars/foo.groovy", "def call() { echo 'foo' }");
+        sampleRepo.git("add", "vars");
+        sampleRepo.git("commit", "--message=init");
+        LibraryConfiguration config = new LibraryConfiguration("library",
+                new SCMSourceRetriever(new GitSCMSource(null, sampleRepo.toString(), "", "*", "", true)));
+        config.setDefaultVersion("master");
+        config.setImplicit(true);
+        config.setCachingConfiguration(new LibraryCachingConfiguration(30, null));
+        GlobalLibraries.get().getLibraries().add(config);
+        // Run build and check that cache gets created.
+        WorkflowJob p = r.createProject(WorkflowJob.class);
+        p.setDefinition(new CpsFlowDefinition("foo()", true));
+        WorkflowRun b = r.buildAndAssertSuccess(p);
+        LibrariesAction action = b.getAction(LibrariesAction.class);
+        LibraryRecord record = action.getLibraries().get(0);
+        FilePath cache = LibraryCachingConfiguration.getGlobalLibrariesCacheDir().child(record.getDirectoryName());
+        assertThat(new File(cache.getRemote()), anExistingDirectory());
+        assertThat(new File(cache.withSuffix("-name.txt").getRemote()), anExistingFile());
+        // Clear the cache. TODO: Would be more realistic to set up security and use WebClient.
+        ExtensionList.lookupSingleton(LibraryCachingConfiguration.DescriptorImpl.class).doClearCache("library");
+        assertThat(new File(cache.getRemote()), not(anExistingDirectory()));
+        assertThat(new File(cache.withSuffix("-name.txt").getRemote()), not(anExistingFile()));
     }
 
 }


### PR DESCRIPTION
The security fixes related to the cache feature in https://github.com/jenkinsci/workflow-cps-global-lib-plugin/commit/ace0de3c2d691662021ea10306eeb407da6b6365 broke `LibraryCachingCleanup` (cleans up unused cache directories) and `LibraryCachingConfiguration.doClearCache` (allows admins to manually delete all cached versions of a specific library). This went unnoticed because neither piece of functionality had any test coverage.

This PR fixes the issues with library cache deletion after SECURITY-2586 and adds relevant test coverage.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
