### PR TITLE
[JENKINS-68375] `LibraryMemoryTest#loaderReleased` fails on Java 17 when `support-core` is present

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryMemoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/libs/LibraryMemoryTest.java
@@ -82,7 +82,7 @@ public class LibraryMemoryTest {
             clearInvocationCaches.invoke(metaClass);
         }
         for (WeakReference<ClassLoader> loaderRef : LOADERS) {
-            MemoryAssert.assertGC(loaderRef, false);
+            MemoryAssert.assertGC(loaderRef);
         }
     }
 


### PR DESCRIPTION
### Context

When testing JENKINS-45047 in `jenkinsci/bom`, I noticed this failure. The failure is probably already occurring in PCT, but due to bugs in PCT we are probably just not seeing it.

### Steps to reproduce

Clone `workflow-cps-global-lib` and add the latest version of `support-core` as a test-scoped dependency, for example with

```xml
diff --git a/pom.xml b/pom.xml
index 3eb584a..9bceb16 100644
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     </pluginRepositories>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.303.1</jenkins.version>
+        <jenkins.version>2.332.1</jenkins.version>
         <java.level>8</java.level>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
@@ -71,8 +71,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.303.x</artifactId>
-                <version>1008.vb9e22885c9cf</version>
+                <artifactId>bom-2.332.x</artifactId>
+                <version>1342.v729ca_3818e88</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -208,5 +208,10 @@
             <version>1.10.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>support-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>
```

and then with Java 17 run `mvn clean verify -Dtest=org.jenkinsci.plugins.workflow.libs.LibraryMemoryTest#loaderReleased`.

### Expected results

**Note:** These are the *actual* results when running with Java 8.

The test passes.

### Actual results

The test fails with

```
<ERROR> Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 40.617 s <<< FAILURE! - in org.jenkinsci.plugins.workflow.libs.LibraryMemoryTest
[ERROR] org.jenkinsci.plugins.workflow.libs.LibraryMemoryTest.loaderReleased  Time elapsed: 40.583 s  <<< FAILURE!
java.lang.AssertionError: 
Apparent soft references to org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxResolvingClassLoader@6e038949: {org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxResolvingClassLoader@6e038949=private static final java.util.logging.LogManager java.util.logging.LogManager.manager->
java.util.logging.LogManager@7f0063f4-rootLogger->
java.util.logging.LogManager$RootLogger@145dbdd2-config->
java.util.logging.Logger$ConfigurationData@2808aef4-handlers->
java.util.concurrent.CopyOnWriteArrayList@31e02cd6-array->
[Ljava.lang.Object;@3ca0805b-[1]->
com.cloudbees.jenkins.support.SupportLogHandler@6b2d6930-records->
[Lcom.cloudbees.jenkins.support.SupportLogHandler$LogRecordRef;@5e2dd628-[9]->
com.cloudbees.jenkins.support.SupportLogHandler$LogRecordRef@276e1d90-referent->
java.util.logging.LogRecord@24f85f67-parameters->
[Ljava.lang.Object;@688471a5-[0]->
org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxResolvingClassLoader@6e038949}; apparent weak references: {org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxResolvingClassLoader@6e038949=private static final java.util.List org.jenkinsci.plugins.workflow.libs.LibraryMemoryTest.LOADERS->
java.util.ArrayList@4db1597-elementData->
[Ljava.lang.Object;@4e72ec4-[7]->
java.lang.ref.WeakReference@19a5c30f-referent->
org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SandboxResolvingClassLoader@6e038949}
        at org.junit.Assert.fail(Assert.java:89)
        at org.jvnet.hudson.test.MemoryAssert.assertGC(MemoryAssert.java:175)
        at org.jenkinsci.plugins.workflow.libs.LibraryMemoryTest.loaderReleased(LibraryMemoryTest.java:85)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:54)
        at org.jvnet.hudson.test.JenkinsRule$1.evaluate(JenkinsRule.java:606)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:299)
        at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:293)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.lang.Thread.run(Thread.java:833)
```

### Evaluation

Based on my reading of https://github.com/jenkinsci/support-core-plugin/pull/324 the code under test is behaving as expected. The test, on the other hand, is wrong in that it expects the code under test to not require a GC.

### Solution

Set `allowSoft` to true. When the test allows for the code under test to require a GC, the scenario passes.