### PR TITLE
Fix test broken by signature changes related to SECURITY-2450

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
     </pluginRepositories>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.303.1</jenkins.version>
+        <jenkins.version>2.332.1</jenkins.version>
         <java.level>8</java.level>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
@@ -71,8 +71,8 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.303.x</artifactId>
-                <version>1008.vb9e22885c9cf</version>
+                <artifactId>bom-2.332.x</artifactId>
+                <version>1382.v7d694476f340</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -94,6 +94,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
+            <version>2692.v76b_089ccd026</version><!-- remove once this version is included in BOM -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -114,6 +115,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
+            <version>1172.v35f6a_0b_8207e</version><!-- remove once this version is included in BOM -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/global/WorkflowLibRepositoryLocalTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/global/WorkflowLibRepositoryLocalTest.java
@@ -65,7 +65,7 @@ public class WorkflowLibRepositoryLocalTest extends Assert {
         assertEquals(cfdd.doCheckScriptCompile(p, "import org.acme.Foo"), CpsFlowDefinitionValidator.CheckStatus.SUCCESS.asJSON());
         assertNotEquals(cfdd.doCheckScriptCompile(p, "import org.acme.NoSuchThing").toString(), CpsFlowDefinitionValidator.CheckStatus.SUCCESS.asJSON().toString()); // control test
         // valid from script-security point of view
-        assertSame(cfdd.doCheckScript("import org.acme.Foo", true), FormValidation.ok());
-        assertSame(cfdd.doCheckScript("import org.acme.NoSuchThing", true), FormValidation.ok());
+        assertSame(cfdd.doCheckScript("import org.acme.Foo", null, true), FormValidation.ok());
+        assertSame(cfdd.doCheckScript("import org.acme.NoSuchThing", null, true), FormValidation.ok());
     }
 }


### PR DESCRIPTION
`CpsFlowDefinition#doCheckScript`'s signature was changed in https://github.com/jenkinsci/workflow-cps-plugin/commit/6bd4e8bf837ba1df4394efdd003c70bb1b9ac33f.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
