### PR TITLE
Fix test compilation errors caused by signature changes in SECURITY-2450

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/global/WorkflowLibRepositoryLocalTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/global/WorkflowLibRepositoryLocalTest.java
@@ -1,7 +1,6 @@
 package org.jenkinsci.plugins.workflow.cps.global;
 
 import com.google.inject.Inject;
-import hudson.util.FormValidation;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.Git;
@@ -64,8 +63,5 @@ public class WorkflowLibRepositoryLocalTest extends Assert {
         WorkflowJob p = j.createProject(WorkflowJob.class);
         assertEquals(cfdd.doCheckScriptCompile(p, "import org.acme.Foo"), CpsFlowDefinitionValidator.CheckStatus.SUCCESS.asJSON());
         assertNotEquals(cfdd.doCheckScriptCompile(p, "import org.acme.NoSuchThing").toString(), CpsFlowDefinitionValidator.CheckStatus.SUCCESS.asJSON().toString()); // control test
-        // valid from script-security point of view
-        assertSame(cfdd.doCheckScript("import org.acme.Foo", true), FormValidation.ok());
-        assertSame(cfdd.doCheckScript("import org.acme.NoSuchThing", true), FormValidation.ok());
     }
 }


### PR DESCRIPTION
Simpler alternative to #169. The signatures of the methods being used in this test changed in https://github.com/jenkinsci/workflow-cps-plugin/commit/6bd4e8bf837ba1df4394efdd003c70bb1b9ac33f, which causes this plugin's tests to fail to compile in the PCT. The assertions are not particularly interesting in this case since the sandbox is being used (see https://github.com/jenkinsci/workflow-cps-plugin/blob/8732e3150b97bd4213401814ba72925ebfa86e0d/src/main/java/org/jenkinsci/plugins/workflow/cps/CpsFlowDefinition.java#L163), so I think it is fine to just delete them to avoid needing to update the minimum Jenkins just to fix this test.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
