### PR TITLE
Forward compatibility with Guice 7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
-  [platform: 'linux', jdk: 17],
-  [platform: 'windows', jdk: 11],
+  [platform: 'linux', jdk: 21],
+  [platform: 'windows', jdk: 17],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.63</version>
+        <version>4.77</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -63,15 +63,15 @@
     </pluginRepositories>
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
-        <jenkins.version>2.361.4</jenkins.version>
+        <jenkins.version>2.414.3</jenkins.version>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.361.x</artifactId>
-                <version>2081.v85885a_d2e5c5</version>
+                <artifactId>bom-2.414.x</artifactId>
+                <version>2718.v7e8a_d43b_3f0b_</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/global/GroovyShellDecoratorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/global/GroovyShellDecoratorImpl.java
@@ -6,7 +6,7 @@ import hudson.Extension;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
 import org.jenkinsci.plugins.workflow.cps.GroovyShellDecorator;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.File;
 import java.net.MalformedURLException;
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/global/UserDefinedGlobalVariableList.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/global/UserDefinedGlobalVariableList.java
@@ -8,7 +8,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.jenkinsci.plugins.workflow.cps.GlobalVariable;
 import org.jenkinsci.plugins.workflow.cps.GlobalVariableSet;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collection;

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/global/UserDefinedGlobalVariableRepoListener.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/global/UserDefinedGlobalVariableRepoListener.java
@@ -24,7 +24,7 @@
 package org.jenkinsci.plugins.workflow.cps.global;
 
 import hudson.Extension;
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import org.kohsuke.accmod.Restricted;
 import org.kohsuke.accmod.restrictions.NoExternalUse;
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/global/WorkflowLibRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/global/WorkflowLibRepository.java
@@ -10,7 +10,7 @@ import org.eclipse.jgit.transport.ReceiveCommand;
 import org.eclipse.jgit.transport.ReceivePack;
 import org.jenkinsci.plugins.gitserver.FileBackedHttpGitRepository;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collection;

--- a/src/main/java/org/jenkinsci/plugins/workflow/cps/global/WorkflowLibSshRepository.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/cps/global/WorkflowLibSshRepository.java
@@ -5,7 +5,7 @@ import org.eclipse.jgit.transport.ReceivePack;
 import org.eclipse.jgit.transport.UploadPack;
 import org.jenkinsci.plugins.gitserver.RepositoryResolver;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.io.IOException;
 
 /**

--- a/src/test/java/org/jenkinsci/plugins/workflow/cps/global/WorkflowLibRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/cps/global/WorkflowLibRepositoryTest.java
@@ -14,7 +14,7 @@ import static org.junit.Assert.*;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
 import org.junit.ClassRule;


### PR DESCRIPTION
Without dropping compatibility with Guice 6 (currently delivered by Jenkins core), add support for Guice 7.